### PR TITLE
Ownerboard CRUD 구현

### DIFF
--- a/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
@@ -29,6 +29,6 @@ public class OwnerBoardController {
 	@PostMapping
 	CommonResponse<OwnerBoardCreateResponseDto> createOwnerBoard(@Valid @RequestBody OwnerBoardCreateRequestDto dto) {
 
-		return CommonResponse.of(SuccessCode.CREATED, ownerBoardService.saveOwnerBoard(dto)); //추가하기
+		return CommonResponse.of(SuccessCode.CREATED, ownerBoardService.saveOwnerBoard(dto));
 	}
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
@@ -1,5 +1,7 @@
 package com.study.petory.domain.ownerBoard.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.study.petory.common.response.CommonResponse;
 import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCreateRequestDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCreateResponseDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetResponseDto;
 import com.study.petory.domain.ownerBoard.service.OwnerBoardService;
 import com.study.petory.exception.enums.SuccessCode;
 
@@ -27,8 +30,20 @@ public class OwnerBoardController {
 	 * @return id, 제목, 내용, 생성일
 	 */
 	@PostMapping
-	CommonResponse<OwnerBoardCreateResponseDto> createOwnerBoard(@Valid @RequestBody OwnerBoardCreateRequestDto dto) {
+	public CommonResponse<OwnerBoardCreateResponseDto> createOwnerBoard(@Valid @RequestBody OwnerBoardCreateRequestDto dto) {
 
 		return CommonResponse.of(SuccessCode.CREATED, ownerBoardService.saveOwnerBoard(dto));
 	}
+
+	/**
+	 * 게시글 단건 조회
+	 * @param boardId 주인커뮤니티 게시글 ID
+	 * @return 게시글 id,제목,내용,작성일,수정일
+	 */
+	@GetMapping("/{boardId}")
+	public CommonResponse<OwnerBoardGetResponseDto> getOwnerBoard(@PathVariable Long boardId) {
+
+		return CommonResponse.of(SuccessCode.OK, ownerBoardService.findOwnerBoard(boardId));
+	}
+
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
@@ -1,6 +1,7 @@
 package com.study.petory.domain.ownerBoard.controller;
 
 import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -37,7 +38,7 @@ public class OwnerBoardController {
 	 * @return id, 제목, 내용, 생성일
 	 */
 	@PostMapping
-	public CommonResponse<OwnerBoardCreateResponseDto> createOwnerBoard(
+	public ResponseEntity<CommonResponse<OwnerBoardCreateResponseDto>> createOwnerBoard(
 		@Valid @RequestBody OwnerBoardCreateRequestDto dto) {
 
 		return CommonResponse.of(SuccessCode.CREATED, ownerBoardService.saveOwnerBoard(dto));
@@ -50,7 +51,7 @@ public class OwnerBoardController {
 	 * @return List형식의 게시글 반환
 	 */
 	@GetMapping
-	public CommonResponse<Page<OwnerBoardGetAllResponseDto>> getOwnerBoardsAll(
+	public ResponseEntity<CommonResponse<Page<OwnerBoardGetAllResponseDto>>> getOwnerBoardsAll(
 		@RequestParam(required = false) String title,
 		@RequestParam(defaultValue = "1") int page) {
 
@@ -63,7 +64,7 @@ public class OwnerBoardController {
 	 * @return 게시글 id,제목,내용,작성일,수정일 //사진 및 댓글리스트 추가 예정
 	 */
 	@GetMapping("/{boardId}")
-	public CommonResponse<OwnerBoardGetResponseDto> getOwnerBoard(@PathVariable Long boardId) {
+	public ResponseEntity<CommonResponse<OwnerBoardGetResponseDto>> getOwnerBoard(@PathVariable Long boardId) {
 
 		return CommonResponse.of(SuccessCode.OK, ownerBoardService.findOwnerBoard(boardId));
 	}
@@ -75,7 +76,7 @@ public class OwnerBoardController {
 	 * @return 수정된 OwnerBoard 반환
 	 */
 	@PatchMapping("/{boardId}")
-	public CommonResponse<OwnerBoardUpdateResponseDto> updateOwnerBoard(
+	public ResponseEntity<CommonResponse<OwnerBoardUpdateResponseDto>> updateOwnerBoard(
 		@PathVariable Long boardId,
 		@Valid @RequestBody OwnerBoardUpdateRequestDto dto) {
 
@@ -88,7 +89,7 @@ public class OwnerBoardController {
 	 * @return NO_CONTENT 성공코드 반환
 	 */
 	@DeleteMapping("/{boardId}")
-	public CommonResponse<Void> deleteOwnerBoard(@PathVariable Long boardId) {
+	public ResponseEntity<CommonResponse<Void>> deleteOwnerBoard(@PathVariable Long boardId) {
 		ownerBoardService.deleteOwnerBoard(boardId);
 
 		return CommonResponse.of(SuccessCode.NO_CONTENT);
@@ -100,7 +101,7 @@ public class OwnerBoardController {
 	 * @return ROLLBACK 성공코드 반환
 	 */
 	@PatchMapping("/{boardId}/restore")
-	public CommonResponse<Void> restoreBoard(@PathVariable Long boardId) {
+	public ResponseEntity<CommonResponse<Void>> restoreBoard(@PathVariable Long boardId) {
 		ownerBoardService.restoreBoard(boardId);
 
 		return CommonResponse.of(SuccessCode.ROLLBACK);

--- a/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
@@ -2,6 +2,7 @@ package com.study.petory.domain.ownerBoard.controller;
 
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,9 +12,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.study.petory.common.response.CommonResponse;
 import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCreateRequestDto;
+import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardUpdateRequestDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCreateResponseDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetAllResponseDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetResponseDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardUpdateResponseDto;
 import com.study.petory.domain.ownerBoard.service.OwnerBoardService;
 import com.study.petory.exception.enums.SuccessCode;
 
@@ -48,8 +51,8 @@ public class OwnerBoardController {
 	@GetMapping
 	public CommonResponse<Page<OwnerBoardGetAllResponseDto>> getOwnerBoardsAll(
 		@RequestParam(required = false) String title,
-		@RequestParam(defaultValue = "1") int page
-	) {
+		@RequestParam(defaultValue = "1") int page) {
+
 		return CommonResponse.of(SuccessCode.OK, ownerBoardService.findAllOwnerBoards(title, page));
 	}
 
@@ -62,5 +65,14 @@ public class OwnerBoardController {
 	public CommonResponse<OwnerBoardGetResponseDto> getOwnerBoard(@PathVariable Long boardId) {
 
 		return CommonResponse.of(SuccessCode.OK, ownerBoardService.findOwnerBoard(boardId));
+	}
+
+	// 게시글 수정
+	@PatchMapping("/{boardId}")
+	public CommonResponse<OwnerBoardUpdateResponseDto> updateOwnerBoard(
+		@PathVariable Long boardId,
+		@Valid @RequestBody OwnerBoardUpdateRequestDto dto) {
+
+		return CommonResponse.of(SuccessCode.OK, ownerBoardService.updateOwnerBoard(boardId, dto));
 	}
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
@@ -1,7 +1,28 @@
 package com.study.petory.domain.ownerBoard.controller;
 
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.study.petory.common.response.CommonResponse;
+import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCreateRequestDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCreateResponseDto;
+import com.study.petory.domain.ownerBoard.service.OwnerBoardService;
+import com.study.petory.exception.enums.SuccessCode;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/owner-boards")
 public class OwnerBoardController {
+
+	private final OwnerBoardService ownerBoardService;
+
+	// 게시글 생성
+	CommonResponse<OwnerBoardCreateResponseDto> createOwnerBoard(@Valid OwnerBoardCreateRequestDto dto) {
+		OwnerBoardCreateResponseDto result = ownerBoardService.saveOwnerBoard(dto);
+
+		return CommonResponse.of(SuccessCode.CREATED, result); //추가하기
+	}
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
@@ -1,15 +1,18 @@
 package com.study.petory.domain.ownerBoard.controller;
 
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.study.petory.common.response.CommonResponse;
 import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCreateRequestDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCreateResponseDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetAllResponseDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetResponseDto;
 import com.study.petory.domain.ownerBoard.service.OwnerBoardService;
 import com.study.petory.exception.enums.SuccessCode;
@@ -26,24 +29,38 @@ public class OwnerBoardController {
 
 	/**
 	 * 게시글 생성
-	 * @param dto 제목, 내용
+	 * @param dto 제목, 내용 //사진 추가 예정
 	 * @return id, 제목, 내용, 생성일
 	 */
 	@PostMapping
-	public CommonResponse<OwnerBoardCreateResponseDto> createOwnerBoard(@Valid @RequestBody OwnerBoardCreateRequestDto dto) {
+	public CommonResponse<OwnerBoardCreateResponseDto> createOwnerBoard(
+		@Valid @RequestBody OwnerBoardCreateRequestDto dto) {
 
 		return CommonResponse.of(SuccessCode.CREATED, ownerBoardService.saveOwnerBoard(dto));
 	}
 
 	/**
+	 * 게시글 전체 조회
+	 * @param title 제목 검색 가능(nullable)
+	 * @param page 조회하려는 페이지 위치
+	 * @return List형식의 게시글 반환
+	 */
+	@GetMapping
+	public CommonResponse<Page<OwnerBoardGetAllResponseDto>> getOwnerBoardsAll(
+		@RequestParam(required = false) String title,
+		@RequestParam(defaultValue = "1") int page
+	) {
+		return CommonResponse.of(SuccessCode.OK, ownerBoardService.findAllOwnerBoards(title, page));
+	}
+
+	/**
 	 * 게시글 단건 조회
 	 * @param boardId 주인커뮤니티 게시글 ID
-	 * @return 게시글 id,제목,내용,작성일,수정일
+	 * @return 게시글 id,제목,내용,작성일,수정일 //사진 및 댓글리스트 추가 예정
 	 */
 	@GetMapping("/{boardId}")
 	public CommonResponse<OwnerBoardGetResponseDto> getOwnerBoard(@PathVariable Long boardId) {
 
 		return CommonResponse.of(SuccessCode.OK, ownerBoardService.findOwnerBoard(boardId));
 	}
-
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
@@ -64,7 +64,8 @@ public class OwnerBoardController {
 	 * @return 게시글 id,제목,내용,작성일,수정일 //사진 및 댓글리스트 추가 예정
 	 */
 	@GetMapping("/{boardId}")
-	public ResponseEntity<CommonResponse<OwnerBoardGetResponseDto>> getOwnerBoard(@PathVariable Long boardId) {
+	public ResponseEntity<CommonResponse<OwnerBoardGetResponseDto>> getOwnerBoard(
+		@PathVariable Long boardId) {
 
 		return CommonResponse.of(SuccessCode.OK, ownerBoardService.findOwnerBoard(boardId));
 	}
@@ -89,7 +90,8 @@ public class OwnerBoardController {
 	 * @return NO_CONTENT 성공코드 반환
 	 */
 	@DeleteMapping("/{boardId}")
-	public ResponseEntity<CommonResponse<Void>> deleteOwnerBoard(@PathVariable Long boardId) {
+	public ResponseEntity<CommonResponse<Void>> deleteOwnerBoard(
+		@PathVariable Long boardId) {
 		ownerBoardService.deleteOwnerBoard(boardId);
 
 		return CommonResponse.of(SuccessCode.NO_CONTENT);
@@ -101,8 +103,9 @@ public class OwnerBoardController {
 	 * @return ROLLBACK 성공코드 반환
 	 */
 	@PatchMapping("/{boardId}/restore")
-	public ResponseEntity<CommonResponse<Void>> restoreBoard(@PathVariable Long boardId) {
-		ownerBoardService.restoreBoard(boardId);
+	public ResponseEntity<CommonResponse<Void>> restoreOwnerBoard(
+		@PathVariable Long boardId) {
+		ownerBoardService.restoreOwnerBoard(boardId);
 
 		return CommonResponse.of(SuccessCode.ROLLBACK);
 	}

--- a/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
@@ -1,6 +1,7 @@
 package com.study.petory.domain.ownerBoard.controller;
 
 import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -79,5 +80,17 @@ public class OwnerBoardController {
 		@Valid @RequestBody OwnerBoardUpdateRequestDto dto) {
 
 		return CommonResponse.of(SuccessCode.OK, ownerBoardService.updateOwnerBoard(boardId, dto));
+	}
+
+	/**
+	 * 게시글 삭제
+	 * @param boardId 삭제할 게시글 ID
+	 * @return no_content status 반환
+	 */
+	@DeleteMapping("/{boardId}")
+	public CommonResponse<Void> deleteOwnerBoard(@PathVariable Long boardId) {
+		ownerBoardService.deleteOwnerBoard(boardId);
+
+		return CommonResponse.of(SuccessCode.NO_CONTENT);
 	}
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
@@ -1,5 +1,7 @@
 package com.study.petory.domain.ownerBoard.controller;
 
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,10 +21,14 @@ public class OwnerBoardController {
 
 	private final OwnerBoardService ownerBoardService;
 
-	// 게시글 생성
-	CommonResponse<OwnerBoardCreateResponseDto> createOwnerBoard(@Valid OwnerBoardCreateRequestDto dto) {
-		OwnerBoardCreateResponseDto result = ownerBoardService.saveOwnerBoard(dto);
+	/**
+	 * 게시글 생성
+	 * @param dto 제목, 내용
+	 * @return id, 제목, 내용, 생성일
+	 */
+	@PostMapping
+	CommonResponse<OwnerBoardCreateResponseDto> createOwnerBoard(@Valid @RequestBody OwnerBoardCreateRequestDto dto) {
 
-		return CommonResponse.of(SuccessCode.CREATED, result); //추가하기
+		return CommonResponse.of(SuccessCode.CREATED, ownerBoardService.saveOwnerBoard(dto)); //추가하기
 	}
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
@@ -85,12 +85,24 @@ public class OwnerBoardController {
 	/**
 	 * 게시글 삭제
 	 * @param boardId 삭제할 게시글 ID
-	 * @return no_content status 반환
+	 * @return NO_CONTENT 성공코드 반환
 	 */
 	@DeleteMapping("/{boardId}")
 	public CommonResponse<Void> deleteOwnerBoard(@PathVariable Long boardId) {
 		ownerBoardService.deleteOwnerBoard(boardId);
 
 		return CommonResponse.of(SuccessCode.NO_CONTENT);
+	}
+
+	/**
+	 * 게시글 복구
+	 * @param boardId 복구할 게시글 ID
+	 * @return ROLLBACK 성공코드 반환
+	 */
+	@PatchMapping("/{boardId}/restore")
+	public CommonResponse<Void> restoreBoard(@PathVariable Long boardId) {
+		ownerBoardService.restoreBoard(boardId);
+
+		return CommonResponse.of(SuccessCode.ROLLBACK);
 	}
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/controller/OwnerBoardController.java
@@ -67,7 +67,12 @@ public class OwnerBoardController {
 		return CommonResponse.of(SuccessCode.OK, ownerBoardService.findOwnerBoard(boardId));
 	}
 
-	// 게시글 수정
+	/**
+	 * 게시글 수정
+	 * @param boardId 수정할 주인커뮤니티 게시글 ID
+	 * @param dto 제목, 내용 // 사진 추가 예정
+	 * @return 수정된 OwnerBoard 반환
+	 */
 	@PatchMapping("/{boardId}")
 	public CommonResponse<OwnerBoardUpdateResponseDto> updateOwnerBoard(
 		@PathVariable Long boardId,

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCreateRequestDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCreateRequestDto.java
@@ -13,7 +13,6 @@ public class OwnerBoardCreateRequestDto {
 	private String title;
 
 	@NotBlank(message = "내용은 필수 입력값 입니다.")
-	@Column(columnDefinition = "TEXT")
 	private String content;
 
 	// photoUrlList 추가 예정

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCreateRequestDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCreateRequestDto.java
@@ -1,0 +1,19 @@
+package com.study.petory.domain.ownerBoard.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class OwnerBoardCreateRequestDto {
+
+	@NotBlank
+	private String title;
+
+	@NotBlank
+	private String content;
+
+	// 사진 여러개 받기 가능
+	private List<String> photoUrls;
+}

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCreateRequestDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCreateRequestDto.java
@@ -2,16 +2,21 @@ package com.study.petory.domain.ownerBoard.dto.request;
 
 import java.util.List;
 
+import jakarta.persistence.Column;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.Singular;
 
 @Getter
 public class OwnerBoardCreateRequestDto {
 
-	@NotBlank
+	@NotBlank(message = "제목은 필수 입력값 입니다.")
+	@Size(max = 30, message = "최대 30자까지 입력할 수 있습니다.")
 	private String title;
 
-	@NotBlank
+	@NotBlank(message = "내용은 필수 입력값 입니다.")
+	@Column(columnDefinition = "TEXT")
 	private String content;
 
 	// 사진 여러개 받기 가능

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCreateRequestDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCreateRequestDto.java
@@ -16,4 +16,6 @@ public class OwnerBoardCreateRequestDto {
 	@Column(columnDefinition = "TEXT")
 	private String content;
 
+	// photoUrlList 추가 예정
+
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCreateRequestDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCreateRequestDto.java
@@ -1,12 +1,9 @@
 package com.study.petory.domain.ownerBoard.dto.request;
 
-import java.util.List;
-
 import jakarta.persistence.Column;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
-import lombok.Singular;
 
 @Getter
 public class OwnerBoardCreateRequestDto {
@@ -19,6 +16,4 @@ public class OwnerBoardCreateRequestDto {
 	@Column(columnDefinition = "TEXT")
 	private String content;
 
-	// 사진 여러개 받기 가능
-	private List<String> photoUrls;
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardUpdateRequestDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardUpdateRequestDto.java
@@ -1,9 +1,6 @@
 package com.study.petory.domain.ownerBoard.dto.request;
 
-import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
-
 import jakarta.persistence.Column;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
@@ -16,9 +13,6 @@ public class OwnerBoardUpdateRequestDto {
 	@Column(columnDefinition = "TEXT")
 	private String content;
 
-	public void update(OwnerBoard ownerBoard) {
-		if(title != null) {ownerBoard.updateTitle(title);}
-		if(content != null) {ownerBoard.updateContent(content);}
-	}
+	// photoUrlList 추가 예정
 
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardUpdateRequestDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardUpdateRequestDto.java
@@ -1,0 +1,24 @@
+package com.study.petory.domain.ownerBoard.dto.request;
+
+import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
+
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class OwnerBoardUpdateRequestDto {
+
+	@Size(max = 30, message = "최대 30자까지 입력할 수 있습니다.")
+	private String title;
+
+	@Column(columnDefinition = "TEXT")
+	private String content;
+
+	public void update(OwnerBoard ownerBoard) {
+		if(title != null) {ownerBoard.updateTitle(title);}
+		if(content != null) {ownerBoard.updateContent(content);}
+	}
+
+}

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardCreateResponseDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardCreateResponseDto.java
@@ -1,0 +1,26 @@
+package com.study.petory.domain.ownerBoard.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OwnerBoardCreateResponseDto {
+
+	private final Long id;
+
+	private final String title;
+
+	private final String content;
+
+	// 사진 여러개 받기 가능
+	private final List<String> photoUrls;
+
+	private final LocalDateTime createdAt;
+}

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardCreateResponseDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardCreateResponseDto.java
@@ -18,6 +18,8 @@ public class OwnerBoardCreateResponseDto {
 
 	private final String content;
 
+	// photoUrlList 추가 예정
+
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 	private final LocalDateTime createdAt;
 

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardCreateResponseDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardCreateResponseDto.java
@@ -1,16 +1,14 @@
 package com.study.petory.domain.ownerBoard.dto.response;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@AllArgsConstructor
 public class OwnerBoardCreateResponseDto {
 
 	private final Long id;
@@ -19,8 +17,16 @@ public class OwnerBoardCreateResponseDto {
 
 	private final String content;
 
-	// 사진 여러개 받기 가능
-	private final List<String> photoUrls;
-
 	private final LocalDateTime createdAt;
+
+	public static OwnerBoardCreateResponseDto from(OwnerBoard ownerBoard) {
+		return new OwnerBoardCreateResponseDto(
+			ownerBoard.getId(),
+			ownerBoard.getTitle(),
+			ownerBoard.getContent(),
+			ownerBoard.getCreatedAt()
+		);
+	}
+
 }
+

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardCreateResponseDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardCreateResponseDto.java
@@ -2,6 +2,7 @@ package com.study.petory.domain.ownerBoard.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 
 import lombok.AllArgsConstructor;
@@ -17,6 +18,7 @@ public class OwnerBoardCreateResponseDto {
 
 	private final String content;
 
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 	private final LocalDateTime createdAt;
 
 	public static OwnerBoardCreateResponseDto from(OwnerBoard ownerBoard) {

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardGetAllResponseDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardGetAllResponseDto.java
@@ -1,0 +1,25 @@
+package com.study.petory.domain.ownerBoard.dto.response;
+
+import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OwnerBoardGetAllResponseDto {
+
+	private final Long id;
+
+	private final String title;
+
+	private final String content;
+
+	public static OwnerBoardGetAllResponseDto from(OwnerBoard ownerBoard) {
+		return new OwnerBoardGetAllResponseDto(
+			ownerBoard.getId(),
+			ownerBoard.getTitle(),
+			ownerBoard.getContent()
+		);
+	}
+}

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardGetResponseDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardGetResponseDto.java
@@ -1,0 +1,35 @@
+package com.study.petory.domain.ownerBoard.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OwnerBoardGetResponseDto {
+
+	private final Long id;
+
+	private final String title;
+
+	private final String content;
+
+	// commentList 추가 예정
+
+	private final LocalDateTime createdAt;
+
+	private final LocalDateTime updatedAt;
+
+	public static OwnerBoardGetResponseDto from(OwnerBoard ownerBoard) {
+		return new OwnerBoardGetResponseDto(
+			ownerBoard.getId(),
+			ownerBoard.getTitle(),
+			ownerBoard.getContent(),
+			ownerBoard.getCreatedAt(),
+			ownerBoard.getUpdatedAt()
+		);
+	}
+}

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardGetResponseDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardGetResponseDto.java
@@ -2,6 +2,7 @@ package com.study.petory.domain.ownerBoard.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 
 import lombok.AllArgsConstructor;
@@ -19,8 +20,10 @@ public class OwnerBoardGetResponseDto {
 
 	// commentList 추가 예정
 
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 	private final LocalDateTime createdAt;
 
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 	private final LocalDateTime updatedAt;
 
 	public static OwnerBoardGetResponseDto from(OwnerBoard ownerBoard) {

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardGetResponseDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardGetResponseDto.java
@@ -18,6 +18,8 @@ public class OwnerBoardGetResponseDto {
 
 	private final String content;
 
+	// photoUrlList 추가 예정
+
 	// commentList 추가 예정
 
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardUpdateResponseDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardUpdateResponseDto.java
@@ -18,6 +18,8 @@ public class OwnerBoardUpdateResponseDto {
 
 	private final String content;
 
+	// photoUrlList 추가 예정
+
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 	private final LocalDateTime updatedAt;
 

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardUpdateResponseDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/response/OwnerBoardUpdateResponseDto.java
@@ -1,0 +1,34 @@
+package com.study.petory.domain.ownerBoard.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OwnerBoardUpdateResponseDto {
+
+	private final Long id;
+
+	private final String title;
+
+	private final String content;
+
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+	private final LocalDateTime updatedAt;
+
+	public static OwnerBoardUpdateResponseDto from(OwnerBoard ownerBoard) {
+		return new OwnerBoardUpdateResponseDto(
+			ownerBoard.getId(),
+			ownerBoard.getTitle(),
+			ownerBoard.getContent(),
+			ownerBoard.getUpdatedAt()
+		);
+	}
+
+}
+

--- a/src/main/java/com/study/petory/domain/ownerBoard/entity/OwnerBoard.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/entity/OwnerBoard.java
@@ -4,16 +4,17 @@ import com.study.petory.common.entity.BaseEntityWithBothAt;
 import com.study.petory.domain.user.entity.User;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 
 @Entity
 @Getter
@@ -31,8 +32,11 @@ public class OwnerBoard extends BaseEntityWithBothAt {
 
 	private String content;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 
+	public void updateTitle(String title) {this.title = title;}
+
+	public void updateContent(String content) {this.content = content;}
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/entity/OwnerBoard.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/entity/OwnerBoard.java
@@ -1,11 +1,14 @@
 package com.study.petory.domain.ownerBoard.entity;
 
 import com.study.petory.common.entity.BaseEntityWithBothAt;
+import com.study.petory.domain.user.entity.User;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 
 @Entity
 public class OwnerBoard extends BaseEntityWithBothAt {
@@ -17,5 +20,11 @@ public class OwnerBoard extends BaseEntityWithBothAt {
 	private String title;
 
 	private String content;
+
+	@ManyToOne
+	@JoinColumn(name = "user_id")
+	private User user;
+
+
 
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/entity/OwnerBoard.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/entity/OwnerBoard.java
@@ -5,6 +5,7 @@ import org.hibernate.annotations.Where;
 import com.study.petory.common.entity.BaseEntityWithBothAt;
 import com.study.petory.domain.user.entity.User;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -28,8 +29,10 @@ public class OwnerBoard extends BaseEntityWithBothAt {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Column(nullable = false,length = 100)
 	private String title;
 
+	@Column(nullable = false, columnDefinition = "TEXT")
 	private String content;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/study/petory/domain/ownerBoard/entity/OwnerBoard.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/entity/OwnerBoard.java
@@ -13,7 +13,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,8 +21,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "owner_board")
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @Where(clause = "deleted_at IS NULL")
 public class OwnerBoard extends BaseEntityWithBothAt {
 
@@ -38,6 +35,13 @@ public class OwnerBoard extends BaseEntityWithBothAt {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
+
+	@Builder
+	public OwnerBoard(String title, String content, User user) {
+		this.title = title;
+		this.content = content;
+		this.user = user;
+	}
 
 	public void updateTitle(String title) {this.title = title;}
 

--- a/src/main/java/com/study/petory/domain/ownerBoard/entity/OwnerBoard.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/entity/OwnerBoard.java
@@ -1,5 +1,7 @@
 package com.study.petory.domain.ownerBoard.entity;
 
+import org.hibernate.annotations.Where;
+
 import com.study.petory.common.entity.BaseEntityWithBothAt;
 import com.study.petory.domain.user.entity.User;
 
@@ -22,6 +24,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Where(clause = "deleted_at IS NULL")
 public class OwnerBoard extends BaseEntityWithBothAt {
 
 	@Id

--- a/src/main/java/com/study/petory/domain/ownerBoard/entity/OwnerBoard.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/entity/OwnerBoard.java
@@ -8,6 +8,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import jakarta.persistence.JoinColumn;
@@ -17,6 +19,8 @@ import jakarta.persistence.ManyToOne;
 @Getter
 @Table(name = "owner_board")
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class OwnerBoard extends BaseEntityWithBothAt {
 
 	@Id
@@ -30,7 +34,5 @@ public class OwnerBoard extends BaseEntityWithBothAt {
 	@ManyToOne
 	@JoinColumn(name = "user_id")
 	private User user;
-
-
 
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/repository/OwnerBoardRepository.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/repository/OwnerBoardRepository.java
@@ -1,8 +1,12 @@
 package com.study.petory.domain.ownerBoard.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 
 public interface OwnerBoardRepository extends JpaRepository<OwnerBoard, Long> {
+
+	Page<OwnerBoard> findByTitleContaining(String title, PageRequest pageRequest);
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/repository/OwnerBoardRepository.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/repository/OwnerBoardRepository.java
@@ -1,12 +1,19 @@
 package com.study.petory.domain.ownerBoard.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 
 public interface OwnerBoardRepository extends JpaRepository<OwnerBoard, Long> {
 
 	Page<OwnerBoard> findByTitleContaining(String title, PageRequest pageRequest);
+
+	@Query(value = "SELECT * FROM owner_board o WHERE o.id = :id", nativeQuery = true)
+	Optional<OwnerBoard> findByIdIncludingDeleted(@Param("id") Long id);
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardService.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardService.java
@@ -15,7 +15,7 @@ import jakarta.validation.Valid;
 public interface OwnerBoardService {
 	OwnerBoard findOwnerBoardById(Long boardId);
 
-	OwnerBoardCreateResponseDto saveOwnerBoard(@Valid OwnerBoardCreateRequestDto dto);
+	OwnerBoardCreateResponseDto saveOwnerBoard(OwnerBoardCreateRequestDto dto);
 
 	Page<OwnerBoardGetAllResponseDto> findAllOwnerBoards(String title, int page);
 
@@ -25,5 +25,5 @@ public interface OwnerBoardService {
 
 	void deleteOwnerBoard(Long boardId);
 
-	void restoreBoard(Long boardId);
+	void restoreOwnerBoard(Long boardId);
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardService.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardService.java
@@ -1,7 +1,10 @@
 package com.study.petory.domain.ownerBoard.service;
 
+import org.springframework.data.domain.Page;
+
 import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCreateRequestDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCreateResponseDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetAllResponseDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetResponseDto;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 
@@ -12,5 +15,8 @@ public interface OwnerBoardService {
 
 	OwnerBoardCreateResponseDto saveOwnerBoard(@Valid OwnerBoardCreateRequestDto dto);
 
+	Page<OwnerBoardGetAllResponseDto> findAllOwnerBoards(String title, int page);
+
 	OwnerBoardGetResponseDto findOwnerBoard(Long boardId);
+
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardService.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardService.java
@@ -2,9 +2,15 @@ package com.study.petory.domain.ownerBoard.service;
 
 import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCreateRequestDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCreateResponseDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetResponseDto;
+import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 
 import jakarta.validation.Valid;
 
 public interface OwnerBoardService {
+	OwnerBoard findOwnerBoardById(Long boardId);
+
 	OwnerBoardCreateResponseDto saveOwnerBoard(@Valid OwnerBoardCreateRequestDto dto);
+
+	OwnerBoardGetResponseDto findOwnerBoard(Long boardId);
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardService.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardService.java
@@ -1,4 +1,10 @@
 package com.study.petory.domain.ownerBoard.service;
 
+import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCreateRequestDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCreateResponseDto;
+
+import jakarta.validation.Valid;
+
 public interface OwnerBoardService {
+	OwnerBoardCreateResponseDto saveOwnerBoard(@Valid OwnerBoardCreateRequestDto dto);
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardService.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardService.java
@@ -24,4 +24,6 @@ public interface OwnerBoardService {
 	OwnerBoardUpdateResponseDto updateOwnerBoard(Long boardId, OwnerBoardUpdateRequestDto dto);
 
 	void deleteOwnerBoard(Long boardId);
+
+	void restoreBoard(Long boardId);
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardService.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardService.java
@@ -22,4 +22,6 @@ public interface OwnerBoardService {
 	OwnerBoardGetResponseDto findOwnerBoard(Long boardId);
 
 	OwnerBoardUpdateResponseDto updateOwnerBoard(Long boardId, OwnerBoardUpdateRequestDto dto);
+
+	void deleteOwnerBoard(Long boardId);
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardService.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardService.java
@@ -3,9 +3,11 @@ package com.study.petory.domain.ownerBoard.service;
 import org.springframework.data.domain.Page;
 
 import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCreateRequestDto;
+import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardUpdateRequestDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCreateResponseDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetAllResponseDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetResponseDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardUpdateResponseDto;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 
 import jakarta.validation.Valid;
@@ -19,4 +21,5 @@ public interface OwnerBoardService {
 
 	OwnerBoardGetResponseDto findOwnerBoard(Long boardId);
 
+	OwnerBoardUpdateResponseDto updateOwnerBoard(Long boardId, OwnerBoardUpdateRequestDto dto);
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
@@ -98,4 +98,22 @@ public class OwnerBoardServiceImpl implements OwnerBoardService {
 		ownerBoard.deactivateEntity();
 	}
 
+	// 게시글 복구
+	@Override
+	@Transactional
+	public void restoreBoard(Long boardId) {
+		// 관리자 권한 검증 로직 추가
+
+		// OwnerBoard ownerBoard = findOwnerBoardById(boardId);
+
+		OwnerBoard ownerBoard = ownerBoardRepository.findByIdIncludingDeleted(boardId)
+			.orElseThrow(() -> new CustomException(ErrorCode.NO_RESOURCE));
+
+		if (ownerBoard.getDeletedAt() == null) {
+			throw new CustomException(ErrorCode.OWNER_BOARD_NOT_DELETED);
+		}
+// 복구에서 막힘
+		ownerBoard.restoreEntity();
+	}
+
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCreateRequestDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCreateResponseDto;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
+import com.study.petory.domain.ownerBoard.repository.OwnerBoardRepository;
 import com.study.petory.domain.user.entity.User;
 import com.study.petory.domain.user.repository.UserRepository;
 
@@ -13,15 +14,22 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class OwnerBoardServiceImpl implements OwnerBoardService {
+	private final OwnerBoardRepository ownerBoardRepository;
 	private final UserRepository userRepository;
 
+	// 게시글 생성
 	@Override
-	public OwnerBoardCreateResponseDto saveOwnerBoard(OwnerBoardCreateRequestDto dto)
-	{
+	public OwnerBoardCreateResponseDto saveOwnerBoard(OwnerBoardCreateRequestDto dto) {
 		User user = userRepository.findById(1L).orElseThrow(); //todo 추후 토큰값으로 수정
 
-		// OwnerBoard ownerBoard =
+		OwnerBoard ownerBoard = OwnerBoard.builder()
+			.title(dto.getTitle())
+			.content(dto.getContent())
+			.user(user)
+			.build();
 
-		return null;
+		ownerBoardRepository.save(ownerBoard);
+
+		return OwnerBoardCreateResponseDto.from(ownerBoard);
 	}
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
@@ -83,7 +83,13 @@ public class OwnerBoardServiceImpl implements OwnerBoardService {
 		// 본인 작성 글인지 검증 로직 추가
 
 		OwnerBoard ownerBoard = findOwnerBoardById(boardId);
-		requestDto.update(ownerBoard);
+
+		if (requestDto.getTitle() != null) {
+			ownerBoard.updateTitle(requestDto.getTitle());
+		}
+		if (requestDto.getContent() != null) {
+			ownerBoard.updateContent(requestDto.getContent());
+		}
 
 		return OwnerBoardUpdateResponseDto.from(ownerBoard);
 	}
@@ -101,7 +107,7 @@ public class OwnerBoardServiceImpl implements OwnerBoardService {
 	// 게시글 복구
 	@Override
 	@Transactional
-	public void restoreBoard(Long boardId) {
+	public void restoreOwnerBoard(Long boardId) {
 		// 관리자 권한 검증 로직 추가
 
 		OwnerBoard ownerBoard = ownerBoardRepository.findByIdIncludingDeleted(boardId)

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
@@ -4,10 +4,13 @@ import org.springframework.stereotype.Service;
 
 import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCreateRequestDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCreateResponseDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetResponseDto;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 import com.study.petory.domain.ownerBoard.repository.OwnerBoardRepository;
 import com.study.petory.domain.user.entity.User;
 import com.study.petory.domain.user.repository.UserRepository;
+import com.study.petory.exception.CustomException;
+import com.study.petory.exception.enums.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,10 +20,16 @@ public class OwnerBoardServiceImpl implements OwnerBoardService {
 	private final OwnerBoardRepository ownerBoardRepository;
 	private final UserRepository userRepository;
 
+	// ownerBoardId로 OwnerBoard 조회
+	@Override
+	public OwnerBoard findOwnerBoardById(Long boardId) {
+		return ownerBoardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NO_RESOURCE));
+	}
+
 	// 게시글 생성
 	@Override
 	public OwnerBoardCreateResponseDto saveOwnerBoard(OwnerBoardCreateRequestDto dto) {
-		User user = userRepository.findById(1L).orElseThrow(); //todo 추후 토큰값으로 수정
+		User user = userRepository.findById(1L).orElseThrow(); // 추후 토큰값으로 수정
 
 		OwnerBoard ownerBoard = OwnerBoard.builder()
 			.title(dto.getTitle())
@@ -31,5 +40,13 @@ public class OwnerBoardServiceImpl implements OwnerBoardService {
 		ownerBoardRepository.save(ownerBoard);
 
 		return OwnerBoardCreateResponseDto.from(ownerBoard);
+	}
+
+	// 게시글 단건 조회
+	@Override
+	public OwnerBoardGetResponseDto findOwnerBoard(Long boardId) {
+		OwnerBoard ownerBoard = findOwnerBoardById(boardId);
+
+		return OwnerBoardGetResponseDto.from(ownerBoard);
 	}
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
@@ -7,9 +7,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCreateRequestDto;
+import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardUpdateRequestDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCreateResponseDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetAllResponseDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetResponseDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardUpdateResponseDto;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 import com.study.petory.domain.ownerBoard.repository.OwnerBoardRepository;
 import com.study.petory.domain.user.entity.User;
@@ -67,10 +69,23 @@ public class OwnerBoardServiceImpl implements OwnerBoardService {
 
 	// 게시글 단건 조회
 	@Override
+	@Transactional(readOnly = true)
 	public OwnerBoardGetResponseDto findOwnerBoard(Long boardId) {
 		OwnerBoard ownerBoard = findOwnerBoardById(boardId);
 
 		return OwnerBoardGetResponseDto.from(ownerBoard);
+	}
+
+	// 게시글 수정
+	@Override
+	@Transactional
+	public OwnerBoardUpdateResponseDto updateOwnerBoard(Long boardId, OwnerBoardUpdateRequestDto requestDto) {
+		// 본인 작성 글인지 검증 로직 추가
+
+		OwnerBoard ownerBoard = findOwnerBoardById(boardId);
+		requestDto.update(ownerBoard);
+
+		return OwnerBoardUpdateResponseDto.from(ownerBoard);
 	}
 
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
@@ -88,4 +88,14 @@ public class OwnerBoardServiceImpl implements OwnerBoardService {
 		return OwnerBoardUpdateResponseDto.from(ownerBoard);
 	}
 
+	// 게시글 삭제
+	@Override
+	@Transactional
+	public void deleteOwnerBoard(Long boardId) {
+		// 본인 작성 글인지 검증 로직 추가
+
+		OwnerBoard ownerBoard = findOwnerBoardById(boardId);
+		ownerBoard.deactivateEntity();
+	}
+
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
@@ -1,9 +1,14 @@
 package com.study.petory.domain.ownerBoard.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCreateRequestDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCreateResponseDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetAllResponseDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetResponseDto;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 import com.study.petory.domain.ownerBoard.repository.OwnerBoardRepository;
@@ -42,6 +47,24 @@ public class OwnerBoardServiceImpl implements OwnerBoardService {
 		return OwnerBoardCreateResponseDto.from(ownerBoard);
 	}
 
+	// 게시글 전체 조회
+	@Override
+	@Transactional(readOnly = true)
+	public Page<OwnerBoardGetAllResponseDto> findAllOwnerBoards(String title, int page) {
+
+		int adjustedPage = (page > 0) ? page - 1 : 0;
+		PageRequest pageRequest = PageRequest.of(adjustedPage, 5, Sort.by("createdAt").descending());
+
+		Page<OwnerBoard> boards;
+		if (title != null) {
+			boards = ownerBoardRepository.findByTitleContaining(title, pageRequest);
+		} else {
+			boards = ownerBoardRepository.findAll(pageRequest);
+		}
+
+		return boards.map(OwnerBoardGetAllResponseDto::from);
+	}
+
 	// 게시글 단건 조회
 	@Override
 	public OwnerBoardGetResponseDto findOwnerBoard(Long boardId) {
@@ -49,4 +72,5 @@ public class OwnerBoardServiceImpl implements OwnerBoardService {
 
 		return OwnerBoardGetResponseDto.from(ownerBoard);
 	}
+
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
@@ -2,6 +2,26 @@ package com.study.petory.domain.ownerBoard.service;
 
 import org.springframework.stereotype.Service;
 
+import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCreateRequestDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCreateResponseDto;
+import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
+import com.study.petory.domain.user.entity.User;
+import com.study.petory.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class OwnerBoardServiceImpl implements OwnerBoardService {
+	private final UserRepository userRepository;
+
+	@Override
+	public OwnerBoardCreateResponseDto saveOwnerBoard(OwnerBoardCreateRequestDto dto)
+	{
+		User user = userRepository.findById(1L).orElseThrow(); //todo 추후 토큰값으로 수정
+
+		// OwnerBoard ownerBoard =
+
+		return null;
+	}
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
@@ -104,15 +104,13 @@ public class OwnerBoardServiceImpl implements OwnerBoardService {
 	public void restoreBoard(Long boardId) {
 		// 관리자 권한 검증 로직 추가
 
-		// OwnerBoard ownerBoard = findOwnerBoardById(boardId);
-
 		OwnerBoard ownerBoard = ownerBoardRepository.findByIdIncludingDeleted(boardId)
 			.orElseThrow(() -> new CustomException(ErrorCode.NO_RESOURCE));
 
 		if (ownerBoard.getDeletedAt() == null) {
 			throw new CustomException(ErrorCode.OWNER_BOARD_NOT_DELETED);
 		}
-// 복구에서 막힘
+
 		ownerBoard.restoreEntity();
 	}
 

--- a/src/main/java/com/study/petory/exception/enums/ErrorCode.java
+++ b/src/main/java/com/study/petory/exception/enums/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode implements BaseCode {
 
 	// OwnerBoard
 	OWNER_BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "글이 존재하지 않습니다."),
+	OWNER_BOARD_NOT_DELETED(HttpStatus.BAD_REQUEST, "삭제되지 않은 게시물은 복구할 수 없습니다."),
 
 	// Place
 	PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "장소가 존재하지 않습니다."),


### PR DESCRIPTION
## #️⃣이슈 번호

close #3 


## 📝작업 상세 내용

- Ownerboard CRUD 로직 구현
- 게시글 생성
- 게시글 전체 조회: 페이징 처리, size 5
- 게시글 단건 조회
- 게시글 수정
- 게시글 삭제: soft delete
- 게시글 복구

15번 이슈(공통 응답 Http 상태코드 수정) 머지되면 바로 반영하겠습니다.

## 💬리뷰 요구사항 (선택)



