### PR TITLE
Test/43 owner board

### DIFF
--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCommentCreateRequestDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCommentCreateRequestDto.java
@@ -2,9 +2,12 @@ package com.study.petory.domain.ownerBoard.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class OwnerBoardCommentCreateRequestDto {
 
 	@NotBlank(message = "내용은 필수 입력 값입니다.")

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCommentUpdateRequestDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCommentUpdateRequestDto.java
@@ -2,9 +2,11 @@ package com.study.petory.domain.ownerBoard.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class OwnerBoardCommentUpdateRequestDto {
 
 	@NotBlank(message = "내용은 필수 입력 값입니다.")

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCreateRequestDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCreateRequestDto.java
@@ -1,11 +1,12 @@
 package com.study.petory.domain.ownerBoard.dto.request;
 
-import jakarta.persistence.Column;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class OwnerBoardCreateRequestDto {
 
 	@NotBlank(message = "제목은 필수 입력값 입니다.")

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCreateRequestDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardCreateRequestDto.java
@@ -2,6 +2,7 @@ package com.study.petory.domain.ownerBoard.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardUpdateRequestDto.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/dto/request/OwnerBoardUpdateRequestDto.java
@@ -3,9 +3,11 @@ package com.study.petory.domain.ownerBoard.dto.request;
 import jakarta.persistence.Column;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class OwnerBoardUpdateRequestDto {
 
 	@NotBlank

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardCommentServiceImpl.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardCommentServiceImpl.java
@@ -30,7 +30,6 @@ public class OwnerBoardCommentServiceImpl implements OwnerBoardCommentService {
 
 	// CommentId로 OwnerBoardComment 조회
 	@Override
-	@Transactional(readOnly = true)
 	public OwnerBoardComment findOwnerBoardCommentById(Long commentId) {
 		return ownerBoardCommentRepository.findById(commentId)
 			.orElseThrow(() -> new CustomException(ErrorCode.OWNER_BOARD_COMMENT_NOT_FOUND));
@@ -57,7 +56,6 @@ public class OwnerBoardCommentServiceImpl implements OwnerBoardCommentService {
 
 	// 주인커뮤니티 댓글 조회
 	@Override
-	@Transactional(readOnly = true)
 	public Page<OwnerBoardCommentGetResponseDto> findAllOwnerBoardComments(Long boardId, Pageable pageable) {
 
 		Page<OwnerBoardComment> comments = ownerBoardCommentRepository.findByOwnerBoardId(boardId, pageable);

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
@@ -148,9 +148,12 @@ public class OwnerBoardServiceImpl implements OwnerBoardService {
 	// 게시글 사진 삭제
 	@Override
 	public void deleteImage(Long boardId, Long imageId) {
-		findOwnerBoardById(boardId);
+		OwnerBoard ownerBoard = findOwnerBoardById(boardId);
+
 		OwnerBoardImage image = ownerBoardImageService.findImageById(imageId);
-		ownerBoardImageService.deleteImageInternal(image);
+
+		ownerBoardImageService.deleteImageInternal(image); // S3 이미지 정보 삭제
+		ownerBoard.getImages().remove(image); // DB 이미지 정보 삭제, 연관관계를 끊어 고아객체로 만들면 delete 쿼리 발생
 	}
 
 }

--- a/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
+++ b/src/main/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceImpl.java
@@ -20,7 +20,6 @@ import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoardComment;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoardImage;
 import com.study.petory.domain.ownerBoard.repository.OwnerBoardCommentRepository;
-import com.study.petory.domain.ownerBoard.repository.OwnerBoardImageRepository;
 import com.study.petory.domain.ownerBoard.repository.OwnerBoardRepository;
 import com.study.petory.domain.user.entity.User;
 import com.study.petory.domain.user.repository.UserRepository;
@@ -36,7 +35,6 @@ public class OwnerBoardServiceImpl implements OwnerBoardService {
 	private final UserRepository userRepository;
 	private final OwnerBoardCommentRepository ownerBoardCommentRepository;
 	private final OwnerBoardImageService ownerBoardImageService;
-	private final OwnerBoardImageRepository ownerBoardImageRepository;
 
 	// ownerBoardId로 OwnerBoard 조회
 	@Override

--- a/src/test/java/com/study/petory/common/util/S3UploaderTest.java
+++ b/src/test/java/com/study/petory/common/util/S3UploaderTest.java
@@ -1,0 +1,76 @@
+package com.study.petory.common.util;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ServiceClientConfiguration;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class S3UploaderTest {
+
+	@Mock
+	private S3Client s3Client;
+
+	@Mock
+	private MultipartFile mockFile;
+
+	@InjectMocks
+	private S3Uploader s3Uploader;
+
+	private String bucket = "petory-static-files";
+
+	@BeforeEach
+	void setBucketField() {
+		ReflectionTestUtils.setField(s3Uploader, "bucket", bucket);
+	}
+
+	@Test
+	void 파일_업로드에_성공한다 () throws IOException {
+		// given
+		String folder = "domain-name";
+		String fileName = "image.jpg";
+		String regionId = "ap-northeast-2";
+
+		// mockFile 관련 mocking
+		given(mockFile.getOriginalFilename()).willReturn(fileName);
+		given(mockFile.getContentType()).willReturn("image/jpeg");
+		given(mockFile.getInputStream()).willReturn(new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)));
+		given(mockFile.getSize()).willReturn(4L);
+
+
+		S3ServiceClientConfiguration mockConfig = mock(S3ServiceClientConfiguration.class);
+		Region mockRegion = mock(Region.class);
+
+		given(s3Client.serviceClientConfiguration()).willReturn(mockConfig);
+		given(mockConfig.region()).willReturn(mockRegion);
+		given(mockRegion.id()).willReturn(regionId);
+
+		// when
+		String result = s3Uploader.uploadFile(mockFile, folder);
+
+		// then
+		assertTrue(result.contains("https://"));
+		assertTrue(result.contains(regionId));
+		assertTrue(result.contains(folder));
+		verify(s3Client).putObject(any(PutObjectRequest.class),any(RequestBody.class));
+	}
+
+}

--- a/src/test/java/com/study/petory/common/util/S3UploaderTest.java
+++ b/src/test/java/com/study/petory/common/util/S3UploaderTest.java
@@ -21,6 +21,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ServiceClientConfiguration;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,7 +56,6 @@ public class S3UploaderTest {
 		given(mockFile.getInputStream()).willReturn(new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)));
 		given(mockFile.getSize()).willReturn(4L);
 
-
 		S3ServiceClientConfiguration mockConfig = mock(S3ServiceClientConfiguration.class);
 		Region mockRegion = mock(Region.class);
 
@@ -71,6 +71,18 @@ public class S3UploaderTest {
 		assertTrue(result.contains(regionId));
 		assertTrue(result.contains(folder));
 		verify(s3Client).putObject(any(PutObjectRequest.class),any(RequestBody.class));
+	}
+
+	@Test
+	void 파일_삭제에_성공한다() {
+		// given
+		String fileKey = "domain-name/1234";
+
+		// when
+		s3Uploader.deleteFile(fileKey);
+
+		// then
+		verify(s3Client, times(1)).deleteObject(any(DeleteObjectRequest.class));
 	}
 
 }

--- a/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardCommentServiceTest.java
+++ b/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardCommentServiceTest.java
@@ -23,11 +23,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCommentCreateRequestDto;
 import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCommentUpdateRequestDto;
-import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardUpdateRequestDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCommentCreateResponseDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCommentGetResponseDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCommentUpdateResponseDto;
-import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardUpdateResponseDto;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoardComment;
 import com.study.petory.domain.ownerBoard.repository.OwnerBoardCommentRepository;
@@ -149,7 +147,26 @@ public class OwnerBoardCommentServiceTest {
 		assertEquals("수정된 댓글", result.getContent());
 	}
 
+	@Test
+	void 댓글_삭제에_성공한다() {
+		// given
+		Long boardId = 10L;
+		Long commentId = 100L;
 
-	// 댓글 삭제
+		OwnerBoardComment comment = OwnerBoardComment.builder()
+			.content("삭제할 댓글")
+			.user(mockUser)
+			.ownerBoard(mockBoard)
+			.build();
+		ReflectionTestUtils.setField(comment, "id", commentId);
 
+		given(ownerBoardCommentRepository.findById(commentId)).willReturn(Optional.of(comment));
+
+		// when
+		ownerBoardCommentService.deleteOwnerBoardComment(boardId, commentId);
+
+		// then
+		assertNotNull(comment.getDeletedAt());
+
+	}
 }

--- a/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardCommentServiceTest.java
+++ b/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardCommentServiceTest.java
@@ -1,0 +1,93 @@
+package com.study.petory.domain.ownerBoard.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCommentCreateRequestDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCommentCreateResponseDto;
+import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
+import com.study.petory.domain.ownerBoard.entity.OwnerBoardComment;
+import com.study.petory.domain.ownerBoard.repository.OwnerBoardCommentRepository;
+import com.study.petory.domain.user.entity.Role;
+import com.study.petory.domain.user.entity.User;
+import com.study.petory.domain.user.entity.UserPrivateInfo;
+import com.study.petory.domain.user.entity.UserRole;
+import com.study.petory.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class OwnerBoardCommentServiceTest {
+
+	@Mock
+	private OwnerBoardCommentRepository ownerBoardCommentRepository;
+
+	@Mock
+	private OwnerBoardService ownerBoardService;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@InjectMocks
+	private OwnerBoardCommentServiceImpl ownerBoardCommentService;
+
+	private User mockUser;
+	private OwnerBoard mockBoard;
+
+	@BeforeEach
+	void SetUser() {
+		List<UserRole> userRole = new ArrayList<>();
+		userRole.add(new UserRole(Role.USER));
+		UserPrivateInfo info = new UserPrivateInfo(1L, "name", "010-0000-0000");
+		this.mockUser = new User("nickname", "test@mail.com", info, userRole);
+		ReflectionTestUtils.setField(mockUser, "id", 1L);
+	}
+
+	@BeforeEach
+	void SetBoard() {
+		this.mockBoard = new OwnerBoard("제목", "내용", mockUser);
+		ReflectionTestUtils.setField(mockBoard, "id", 1L);
+	}
+
+	@Test
+	void 댓글_생성에_성공한다() {
+		// given
+		Long userId = 1L;
+		Long boardId = 1L;
+		OwnerBoardCommentCreateRequestDto requestDto = new OwnerBoardCommentCreateRequestDto("새 댓글");
+
+		OwnerBoardComment comment = OwnerBoardComment.builder()
+			.content("새 댓글")
+			.user(mockUser)
+			.ownerBoard(mockBoard)
+			.build();
+
+		given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+		given(ownerBoardService.findOwnerBoardById(boardId)).willReturn(mockBoard);
+		given(ownerBoardCommentRepository.save(any())).willReturn(comment);
+
+		// when
+		OwnerBoardCommentCreateResponseDto result =
+			ownerBoardCommentService.saveOwnerBoardComment(boardId, requestDto);
+
+		// then
+		assertEquals("새 댓글", result.getContent());
+	}
+
+
+	// 댓글 조회
+	// 댓글 수정
+	// 댓글 삭제
+
+}

--- a/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardCommentServiceTest.java
+++ b/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardCommentServiceTest.java
@@ -22,8 +22,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCommentCreateRequestDto;
+import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCommentUpdateRequestDto;
+import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardUpdateRequestDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCommentCreateResponseDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCommentGetResponseDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCommentUpdateResponseDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardUpdateResponseDto;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoardComment;
 import com.study.petory.domain.ownerBoard.repository.OwnerBoardCommentRepository;
@@ -63,14 +67,14 @@ public class OwnerBoardCommentServiceTest {
 	@BeforeEach
 	void SetBoard() {
 		this.mockBoard = new OwnerBoard("제목", "내용", mockUser);
-		ReflectionTestUtils.setField(mockBoard, "id", 1L);
+		ReflectionTestUtils.setField(mockBoard, "id", 10L);
 	}
 
 	@Test
 	void 댓글_생성에_성공한다() {
 		// given
 		Long userId = 1L;
-		Long boardId = 1L;
+		Long boardId = 10L;
 		OwnerBoardCommentCreateRequestDto requestDto = new OwnerBoardCommentCreateRequestDto("새 댓글");
 
 		OwnerBoardComment comment = OwnerBoardComment.builder()
@@ -120,7 +124,32 @@ public class OwnerBoardCommentServiceTest {
 		assertEquals("댓글 1", result.getContent().get(1).getContent());
 	}
 
-	// 댓글 수정
+	@Test
+	void 댓글_수정에_성공한다() {
+		// given
+		Long boardId = 10L;
+		Long commentId = 100L;
+
+		OwnerBoardComment comment = OwnerBoardComment.builder()
+			.content("기존 댓글")
+			.user(mockUser)
+			.ownerBoard(mockBoard)
+			.build();
+		ReflectionTestUtils.setField(comment, "id", commentId);
+
+		given(ownerBoardCommentRepository.findById(commentId)).willReturn(Optional.of(comment));
+
+		OwnerBoardCommentUpdateRequestDto requestDto = new OwnerBoardCommentUpdateRequestDto("수정된 댓글");
+
+		// when
+		OwnerBoardCommentUpdateResponseDto result = ownerBoardCommentService.updateOwnerBoardComment(
+			boardId, commentId, requestDto);
+
+		// then
+		assertEquals("수정된 댓글", result.getContent());
+	}
+
+
 	// 댓글 삭제
 
 }

--- a/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardCommentServiceTest.java
+++ b/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardCommentServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,10 +15,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCommentCreateRequestDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCommentCreateResponseDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCommentGetResponseDto;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoardComment;
 import com.study.petory.domain.ownerBoard.repository.OwnerBoardCommentRepository;
@@ -85,8 +91,35 @@ public class OwnerBoardCommentServiceTest {
 		assertEquals("새 댓글", result.getContent());
 	}
 
+	@Test
+	void 댓글_전체_조회에_성공한다() {
+		// given
+		Long boardId = 1L;
+		Pageable pageable = PageRequest.of(0, 10);
 
-	// 댓글 조회
+		List<OwnerBoardComment> mockList = IntStream.range(0, 15)
+			.mapToObj(i -> OwnerBoardComment.builder()
+				.content("댓글 " + i)
+				.user(mockUser)
+				.ownerBoard(mockBoard)
+				.build())
+			.toList();
+
+		Page<OwnerBoardComment> mockPage = new PageImpl<>(
+			mockList.subList(0, 10), pageable, mockList.size());
+
+		given(ownerBoardCommentRepository.findByOwnerBoardId(boardId, pageable)).willReturn(mockPage);
+
+		// when
+		Page<OwnerBoardCommentGetResponseDto> result = ownerBoardCommentService.findAllOwnerBoardComments(
+			boardId, pageable);
+
+		// then
+		assertEquals(15, result.getTotalElements());
+		assertEquals(10, result.getContent().size());
+		assertEquals("댓글 1", result.getContent().get(1).getContent());
+	}
+
 	// 댓글 수정
 	// 댓글 삭제
 

--- a/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceTest.java
+++ b/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceTest.java
@@ -25,9 +25,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCreateRequestDto;
+import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardUpdateRequestDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCreateResponseDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetAllResponseDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetResponseDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardUpdateResponseDto;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoardComment;
 import com.study.petory.domain.ownerBoard.repository.OwnerBoardCommentRepository;
@@ -89,12 +91,12 @@ public class OwnerBoardServiceTest {
 		given(ownerBoardImageService.uploadAndSaveAll(any(), any())).willReturn(mockUrls);
 
 		// when
-		OwnerBoardCreateResponseDto response = ownerBoardService.saveOwnerBoard(requestDto, images);
+		OwnerBoardCreateResponseDto result = ownerBoardService.saveOwnerBoard(requestDto, images);
 
 		// then
-		assertThat(response.getTitle()).isEqualTo("제목");
-		assertThat(response.getContent()).isEqualTo("내용");
-		assertThat(response.getImageUrls()).containsExactlyElementsOf(mockUrls);
+		assertThat(result.getTitle()).isEqualTo("제목");
+		assertThat(result.getContent()).isEqualTo("내용");
+		assertThat(result.getImageUrls()).containsExactlyElementsOf(mockUrls);
 	}
 
 	@Test
@@ -113,12 +115,12 @@ public class OwnerBoardServiceTest {
 		given(ownerBoardRepository.save(any(OwnerBoard.class))).willReturn(mockBoard);
 
 		// when
-		OwnerBoardCreateResponseDto response = ownerBoardService.saveOwnerBoard(requestDto, images);
+		OwnerBoardCreateResponseDto result = ownerBoardService.saveOwnerBoard(requestDto, images);
 
 		// then
-		assertThat(response.getTitle()).isEqualTo("제목");
-		assertThat(response.getContent()).isEqualTo("내용");
-		assertTrue(response.getImageUrls().isEmpty());
+		assertThat(result.getTitle()).isEqualTo("제목");
+		assertThat(result.getContent()).isEqualTo("내용");
+		assertTrue(result.getImageUrls().isEmpty());
 		verify(ownerBoardImageService, never()).uploadAndSaveAll(any(), any());
 	}
 
@@ -197,17 +199,42 @@ public class OwnerBoardServiceTest {
 		given(ownerBoardCommentRepository.findTop10ByOwnerBoardIdOrderByCreatedAt(boardId)).willReturn(mockComments);
 
 		// when
-		OwnerBoardGetResponseDto responseDto = ownerBoardService.findOwnerBoard(boardId);
+		OwnerBoardGetResponseDto result = ownerBoardService.findOwnerBoard(boardId);
 
 		// then
-		assertEquals("제목", responseDto.getTitle());
-		assertEquals("내용", responseDto.getContent());
-		assertEquals(2, responseDto.getImages().size());
-		assertEquals(10, responseDto.getCommentsList().size());
+		assertEquals("제목", result.getTitle());
+		assertEquals("내용", result.getContent());
+		assertEquals(2, result.getImages().size());
+		assertEquals(10, result.getCommentsList().size());
 	}
 
-	// 유저소통_게시글_수정에_성공한다
-	// 유저소통_게시글_삭제에_성공한다
+	@Test
+	void 게시글_수정에_성공한다() {
+		// given
+		Long boardId = 1L;
+		OwnerBoard originalBoard = OwnerBoard.builder()
+			.title("원래 제목")
+			.content("원래 내용")
+			.user(mockUser)
+			.build();
+
+		ReflectionTestUtils.setField(originalBoard,"id", boardId);
+		OwnerBoardUpdateRequestDto requestDto = new OwnerBoardUpdateRequestDto("수정된 제목", "수정된 내용");
+
+		given(ownerBoardRepository.findByIdWithImages(boardId)).willReturn(Optional.of(originalBoard));
+
+		// when
+		OwnerBoardUpdateResponseDto result = ownerBoardService.updateOwnerBoard(boardId, requestDto);
+
+		// then
+		assertEquals("수정된 제목", result.getTitle());
+		assertEquals("수정된 내용", result.getContent());
+	}
+
+
+	// 게시글_삭제에_성공한다
+
+	// 게시글_복구에_성공한다
 	// 유저소통_게시글_사진_삭제에_성공한다
 
 }

--- a/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceTest.java
+++ b/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceTest.java
@@ -32,6 +32,7 @@ import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardGetResponseDto;
 import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardUpdateResponseDto;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
 import com.study.petory.domain.ownerBoard.entity.OwnerBoardComment;
+import com.study.petory.domain.ownerBoard.entity.OwnerBoardImage;
 import com.study.petory.domain.ownerBoard.repository.OwnerBoardCommentRepository;
 import com.study.petory.domain.ownerBoard.repository.OwnerBoardRepository;
 import com.study.petory.domain.user.entity.Role;
@@ -158,7 +159,7 @@ public class OwnerBoardServiceTest {
 		Pageable pageable = PageRequest.of(0, 5);
 		List<OwnerBoard> mockList = List.of(
 			OwnerBoard.builder().title("제목입니다").content("내용").build(),
-			OwnerBoard.builder().title("포함안된 글").content("내용").build()
+			OwnerBoard.builder().title("두번째 글").content("내용").build()
 		);
 
 		Page<OwnerBoard> mockPage = new PageImpl<>(mockList);
@@ -231,8 +232,32 @@ public class OwnerBoardServiceTest {
 		assertEquals("수정된 내용", result.getContent());
 	}
 
+	@Test
+	void 게시글_삭제에_성공한다() {
+		// given
+		Long boardId = 1L;
 
-	// 게시글_삭제에_성공한다
+		OwnerBoardImage image1 = mock(OwnerBoardImage.class);
+		OwnerBoardImage image2 = mock(OwnerBoardImage.class);
+
+		OwnerBoard board = OwnerBoard.builder()
+			.title("제목")
+			.content("내용")
+			.user(mockUser)
+			.build();
+		ReflectionTestUtils.setField(board, "id", boardId);
+		ReflectionTestUtils.setField(board, "images", new ArrayList<>(List.of(image1, image2)));
+
+		given(ownerBoardRepository.findByIdWithImages(boardId)).willReturn(Optional.of(board));
+
+		// when
+		ownerBoardService.deleteOwnerBoard(boardId);
+
+		// then
+		verify(ownerBoardImageService, times(2)).deleteImage(any());
+		assertTrue(board.getImages().isEmpty());
+		assertNotNull(board.getDeletedAt());
+	}
 
 	// 게시글_복구에_성공한다
 	// 유저소통_게시글_사진_삭제에_성공한다

--- a/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceTest.java
+++ b/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceTest.java
@@ -1,6 +1,7 @@
 package com.study.petory.domain.ownerBoard.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.ArrayList;
@@ -54,15 +55,16 @@ public class OwnerBoardServiceTest {
 	}
 
 	@Test
-	void 유저소통_게시글과_이미지를_함께_저장에_성공다() {
+	void 유저소통_게시글_저장에_성공한다_이미지_포함() {
 		// given
-		OwnerBoardCreateRequestDto dto = new OwnerBoardCreateRequestDto("제목", "내용");
+		OwnerBoardCreateRequestDto requestDto = new OwnerBoardCreateRequestDto("제목", "내용");
 
 		List<MultipartFile> images = List.of(
 			new MockMultipartFile("image", "test.jpg", "image/jpeg", "image data".getBytes())
 		);
 
-		OwnerBoard mockBoard = OwnerBoard.builder().title("제목")
+		OwnerBoard mockBoard = OwnerBoard.builder()
+			.title("제목")
 			.content("내용")
 			.user(mockUser)
 			.build();
@@ -74,7 +76,7 @@ public class OwnerBoardServiceTest {
 		given(ownerBoardImageService.uploadAndSaveAll(any(), any())).willReturn(mockUrls);
 
 		// when
-		OwnerBoardCreateResponseDto response = ownerBoardService.saveOwnerBoard(dto, images);
+		OwnerBoardCreateResponseDto response = ownerBoardService.saveOwnerBoard(requestDto, images);
 
 		// then
 		assertThat(response.getTitle()).isEqualTo("제목");
@@ -82,7 +84,31 @@ public class OwnerBoardServiceTest {
 		assertThat(response.getImageUrls()).containsExactlyElementsOf(mockUrls);
 	}
 
-	// 유저소통_게시글_저장에_성공한다.
+	@Test
+	void 유저소통_게시글_저장에_성공한다_이미지_미포함() {
+		// given
+		OwnerBoardCreateRequestDto requestDto = new OwnerBoardCreateRequestDto("제목", "내용");
+		List<MultipartFile> images = null;
+
+		OwnerBoard mockBoard = OwnerBoard.builder()
+			.title("제목")
+			.content("내용")
+			.user(mockUser)
+			.build();
+
+		given(userRepository.findById(1L)).willReturn(Optional.of(mockUser));
+		given(ownerBoardRepository.save(any(OwnerBoard.class))).willReturn(mockBoard);
+
+		// when
+		OwnerBoardCreateResponseDto response = ownerBoardService.saveOwnerBoard(requestDto, images);
+
+		// then
+		assertThat(response.getTitle()).isEqualTo("제목");
+		assertThat(response.getContent()).isEqualTo("내용");
+		assertTrue(response.getImageUrls().isEmpty());
+		verify(ownerBoardImageService, never()).uploadAndSaveAll(any(), any());
+	}
+
 	// 유저소통_게시글_검색어_없이_전체_조회에_성공한다
 	// 유저소통_게시글_검색어_포함_전체_조회에_성공한다
 	// 유저소통_게시글_단건_조회에_성공한다

--- a/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceTest.java
+++ b/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceTest.java
@@ -282,6 +282,36 @@ public class OwnerBoardServiceTest {
 		assertNull(deletedBoard.getDeletedAt());
 	}
 
-	// 유저소통_게시글_사진_삭제에_성공한다
+	@Test
+	void 게시글의_사진_삭제에_성공한다() {
+		// given
+		Long boardId = 1L;
+		Long imageId = 10L;
+
+		OwnerBoard board = OwnerBoard.builder()
+			.title("제목")
+			.content("내용")
+			.user(mockUser)
+			.build();
+
+		OwnerBoardImage image1 = mock(OwnerBoardImage.class);
+		ReflectionTestUtils.setField(image1, "id", imageId);
+		OwnerBoardImage image2 = mock(OwnerBoardImage.class);
+
+		ReflectionTestUtils.setField(board, "id", boardId);
+		ReflectionTestUtils.setField(board, "images", new ArrayList<>(List.of(image1, image2)));
+
+		given(ownerBoardRepository.findByIdWithImages(boardId)).willReturn(Optional.of(board));
+		given(ownerBoardImageService.findImageById(imageId)).willReturn(image1);
+
+		// when
+		ownerBoardService.deleteImage(boardId, imageId);
+
+		// then
+		verify(ownerBoardRepository).findByIdWithImages(boardId);
+		verify(ownerBoardImageService).findImageById(imageId);
+		verify(ownerBoardImageService).deleteImageInternal(image1);
+		assertEquals(1, board.getImages().size());
+	}
 
 }

--- a/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceTest.java
+++ b/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceTest.java
@@ -1,0 +1,93 @@
+package com.study.petory.domain.ownerBoard.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.study.petory.domain.ownerBoard.dto.request.OwnerBoardCreateRequestDto;
+import com.study.petory.domain.ownerBoard.dto.response.OwnerBoardCreateResponseDto;
+import com.study.petory.domain.ownerBoard.entity.OwnerBoard;
+import com.study.petory.domain.ownerBoard.repository.OwnerBoardRepository;
+import com.study.petory.domain.user.entity.Role;
+import com.study.petory.domain.user.entity.User;
+import com.study.petory.domain.user.entity.UserPrivateInfo;
+import com.study.petory.domain.user.entity.UserRole;
+import com.study.petory.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class OwnerBoardServiceTest {
+
+	@Mock
+	private OwnerBoardRepository ownerBoardRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private OwnerBoardImageService ownerBoardImageService;
+
+	@InjectMocks
+	private OwnerBoardServiceImpl ownerBoardService;
+
+	private User mockUser;
+
+	@BeforeEach
+	void SetUser() {
+		List<UserRole> userRole = new ArrayList<>();
+		userRole.add(new UserRole(Role.USER));
+		UserPrivateInfo info = new UserPrivateInfo(1L, "name", "010-0000-0000");
+		this.mockUser = new User("nickname", "test@mail.com", info, userRole);
+		ReflectionTestUtils.setField(mockUser, "id", 1L);
+	}
+
+	@Test
+	void 유저소통_게시글과_이미지를_함께_저장에_성공다() {
+		// given
+		OwnerBoardCreateRequestDto dto = new OwnerBoardCreateRequestDto("제목", "내용");
+
+		List<MultipartFile> images = List.of(
+			new MockMultipartFile("image", "test.jpg", "image/jpeg", "image data".getBytes())
+		);
+
+		OwnerBoard mockBoard = OwnerBoard.builder().title("제목")
+			.content("내용")
+			.user(mockUser)
+			.build();
+
+		List<String> mockUrls = List.of("https://s3.url/test1.jpg", "https://s3.url/test2.jpg");
+
+		given(userRepository.findById(1L)).willReturn(Optional.of(mockUser));
+		given(ownerBoardRepository.save(any(OwnerBoard.class))).willReturn(mockBoard);
+		given(ownerBoardImageService.uploadAndSaveAll(any(), any())).willReturn(mockUrls);
+
+		// when
+		OwnerBoardCreateResponseDto response = ownerBoardService.saveOwnerBoard(dto, images);
+
+		// then
+		assertThat(response.getTitle()).isEqualTo("제목");
+		assertThat(response.getContent()).isEqualTo("내용");
+		assertThat(response.getImageUrls()).containsExactlyElementsOf(mockUrls);
+	}
+
+	// 유저소통_게시글_저장에_성공한다.
+	// 유저소통_게시글_검색어_없이_전체_조회에_성공한다
+	// 유저소통_게시글_검색어_포함_전체_조회에_성공한다
+	// 유저소통_게시글_단건_조회에_성공한다
+	// 유저소통_게시글_수정에_성공한다
+	// 유저소통_게시글_삭제에_성공한다
+	// 유저소통_게시글_사진_삭제에_성공한다
+
+}

--- a/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceTest.java
+++ b/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceTest.java
@@ -186,7 +186,7 @@ public class OwnerBoardServiceTest {
 			.build();
 
 		List<OwnerBoardComment> mockComments = IntStream.range(0, 10)
-			.mapToObj(i ->  OwnerBoardComment.builder()
+			.mapToObj(i -> OwnerBoardComment.builder()
 				.content("댓글 " + i)
 				.user(mockUser)
 				.ownerBoard(mockBoard)
@@ -220,7 +220,7 @@ public class OwnerBoardServiceTest {
 			.user(mockUser)
 			.build();
 
-		ReflectionTestUtils.setField(originalBoard,"id", boardId);
+		ReflectionTestUtils.setField(originalBoard, "id", boardId);
 		OwnerBoardUpdateRequestDto requestDto = new OwnerBoardUpdateRequestDto("수정된 제목", "수정된 내용");
 
 		given(ownerBoardRepository.findByIdWithImages(boardId)).willReturn(Optional.of(originalBoard));

--- a/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceTest.java
+++ b/src/test/java/com/study/petory/domain/ownerBoard/service/OwnerBoardServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -259,7 +260,28 @@ public class OwnerBoardServiceTest {
 		assertNotNull(board.getDeletedAt());
 	}
 
-	// 게시글_복구에_성공한다
+	@Test
+	void 게시글_복구에_성공한다() {
+		// given
+		Long boardId = 1L;
+
+		OwnerBoard deletedBoard = OwnerBoard.builder()
+			.title("삭제된 제목")
+			.content("삭제된 내용")
+			.user(mockUser)
+			.build();
+		ReflectionTestUtils.setField(deletedBoard, "id", boardId);
+		ReflectionTestUtils.setField(deletedBoard, "deletedAt", LocalDateTime.now());
+
+		given(ownerBoardRepository.findByIdIncludingDeleted(boardId)).willReturn(Optional.of(deletedBoard));
+
+		// when
+		ownerBoardService.restoreOwnerBoard(boardId);
+
+		// then
+		assertNull(deletedBoard.getDeletedAt());
+	}
+
 	// 유저소통_게시글_사진_삭제에_성공한다
 
 }


### PR DESCRIPTION
## #️⃣이슈 번호

close #43


## 📝작업 상세 내용

- [x] ownerboard, ownerboardcomment 도메인 서비스 레이어 성공 테스트 
- [x] S3업로드 성공 테스트
- [x] abstractImageService, OwnerBoardImageService는 ownerBoard 서비스에 흐름이 포함되어 있어서 통합적으로 테스트가 진행되었습니다.


## 테스트 커버리지
![image](https://github.com/user-attachments/assets/7deb9bab-909e-4404-90f9-3a439446cfcb)
![image](https://github.com/user-attachments/assets/58a36b1a-bfc2-47ee-a095-c24c8a008ada)
![image](https://github.com/user-attachments/assets/11f63982-9bf0-407c-9857-5cffb1044ccc)



## 💬리뷰 요구사항 (선택)
