### PR TITLE
Feat/29 o auth

### DIFF
--- a/src/main/java/com/study/petory/common/config/SecurityConfig.java
+++ b/src/main/java/com/study/petory/common/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -60,21 +61,23 @@ public class SecurityConfig {
 			.formLogin(AbstractHttpConfigurer::disable)
 			.logout(AbstractHttpConfigurer::disable)
 			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			// TODO - 배포 전 체크
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(
 					"/auth/**",
 					"/login/**",
 					"/users/signup",
 					"/users/login",
-					"/oauth2/**",       // 소셜 로그인 진입점 (예: /oauth2/authorization/google)
-					"/login/oauth2/**", // 소셜 로그인 콜백 URI (예: /login/oauth2/code/google)
+					"/oauth2/**",       		      // 소셜 로그인 진입점 (예: /oauth2/authorization/google)
+					"/login/oauth2/**", 		      // 소셜 로그인 콜백 URI (예: /login/oauth2/code/google)
 					"/error",
-					"/login.html",
-					"/login-success.html",
+					"/login.html",                  // 프론트 로그인 진입점
+					"/login-success.html",          // 프론트 로그인 성공 시 진입점
 					"/css/**",
 					"/js/**",
 					"/images/**"
 				).permitAll()
+				.requestMatchers(HttpMethod.GET, "/owner-boards/**").permitAll()  // /owner-boards 하위의 경로 중 GET 매핑만 모두 허용
 				.anyRequest().authenticated()
 			)
 

--- a/src/main/java/com/study/petory/common/exception/enums/ErrorCode.java
+++ b/src/main/java/com/study/petory/common/exception/enums/ErrorCode.java
@@ -22,6 +22,8 @@ public enum ErrorCode implements BaseCode {
 	WRONG_SIGNATURE(HttpStatus.UNAUTHORIZED, "잘못된 서명입니다."),
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
 	INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다."),
+	USER_ID_NOT_GENERATED(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 정보를 저장했지만 ID가 생성되지 않았습니다."),
+	OAUTH2_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "OAuth2 인증에 이메일 정보가 없습니다."),
 
 	// pet
 	PET_NOT_FOUND(HttpStatus.NOT_FOUND, "펫이 존재하지 않습니다."),

--- a/src/main/java/com/study/petory/common/security/JwtFilter.java
+++ b/src/main/java/com/study/petory/common/security/JwtFilter.java
@@ -23,14 +23,16 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
-// TODO - ResponseStatusException 대신 CustomException 으로 통일
+/*
+ * OncePerRequestFilter 를 상속받아 HTTP 요청당 한 번만 실행
+ * JWT 인증 필터 - HTTP 요청마다 실행
+ * 인증 필요 없는 경로는 WHITELIST 로 필터링하고, 나머지는 JWT 검증 처리
+ */
 @Slf4j
 @Component
-// OncePerRequestFilter 를 상속받아 HTTP 요청당 한 번만 실행
 public class JwtFilter extends OncePerRequestFilter {
 
 	private final JwtProvider jwtProvider;
-
 	private final RedisTemplate<String, String> loginRefreshToken;
 
 	public JwtFilter(
@@ -42,8 +44,7 @@ public class JwtFilter extends OncePerRequestFilter {
 		this.loginRefreshToken = loginRefreshToken;
 	}
 
-	// TODO - URL 추가 및 수정 필요
-	// WHITELIST
+	// WHITELIST (인증이 필요 없는 경로 리스트)
 	private static final List<String> WHITELIST = List.of(
 		"/auth/login",
 		"/users/signup",
@@ -56,117 +57,98 @@ public class JwtFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 
-		// HttpServletRequest 에서 요청된 URI 경로를 문자열로 추출
+		// 요청 URI
 		String url = request.getRequestURI();
 		debugLog("요청 URI: " + url);
 
-		// WHITELIST or 정적 리소스는 필터 우회
+		// 정적 리소스 또는 화이트리스트 우회
 		if (url.matches(".*(\\.html|\\.css|\\.js|\\.png|\\.jpg|\\.ico)$") || WHITELIST.contains(url)) {
 			debugLog("WHITELIST 경로입니다. 필터 우회: " + url);
 			filterChain.doFilter(request, response);
-
 			return;
 		}
 
-		// 1. 클라이언트가 HTTP 요청에 Authorization 헤더 포함시켰는지 확인
+		// 1. Authorization 헤더 확인
 		String bearerJwt = request.getHeader("Authorization");
 
-		// 쿼리 파라미터에서도 accessToken 시도 (테스트 목적)
+		// 2. 쿼리 파라미터 accessToken 도 허용 (테스트 등)
 		if (bearerJwt == null) {
 			String queryToken = request.getParameter("accessToken");
-			if (queryToken.startsWith("Bearer ")) {
-				bearerJwt = queryToken;
-			} else {
-				bearerJwt = "Bearer " + queryToken;
+			if (queryToken != null) { // <-- NPE 방지! (수정포인트)
+				if (queryToken.startsWith("Bearer ")) {
+					bearerJwt = queryToken;
+				} else {
+					bearerJwt = "Bearer " + queryToken;
+				}
+				debugLog("accessToken 쿼리 파라미터 사용: " + bearerJwt);
 			}
-			debugLog("accessToken 쿼리 파라미터 사용: " + bearerJwt);
 		}
 
+		// 3. 최종적으로 bearerJwt 가 null이면 인증 실패
 		if (bearerJwt == null) {
 			debugLog("Authorization 헤더 없음. 필터 중단");
 			writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "Authorization 헤더가 존재하지 않습니다.");
 			return;
 		}
 
-		// 헤더는 있으나 "Bearer " 형식이 아닐 때 (값이 비어 있거나 다른 형식)
+		// 4. Bearer 형식 확인
 		if (!bearerJwt.startsWith("Bearer ")) {
-			writeErrorResponse(response, HttpStatus.UNAUTHORIZED,
-				"유효한 Bearer 토큰이 없습니다.");
+			writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "유효한 Bearer 토큰이 없습니다.");
 			return;
 		}
 
-		// 2) "Bearer " 제거 + 유효성 검사 : subStringToken()
+		// 5. Bearer 제거 및 토큰 추출, 유효성 검사
 		String rawToken;
-
 		try {
 			rawToken = jwtProvider.subStringToken(bearerJwt);
 			debugLog("추출된 JWT: " + rawToken);
 		} catch (CustomException e) {
 			writeErrorResponse(response, e.getErrorCode().getStatus(), e.getMessage());
-
 			return;
 		}
 
-		// 3) 블랙리스트 체크
+		// 6. 블랙리스트(로그아웃) 토큰 체크
 		if (loginRefreshToken.hasKey("BLACKLIST_" + rawToken)) {
 			writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다.");
 			return;
 		}
 
+		// 7. 토큰 파싱 및 인증정보 등록
 		try {
-			/*
-			 * 4) 토큰 파싱
-			 * 내부에서 토큰의 유효성 검증 → Claims 객체로 반환
-			 */
 			Claims claims = jwtProvider.parseRawToken(rawToken);
-
-			// Claims 는 JWT 내부 payload 정보들을 갖고 있어 getSubject() 로 값 추출 가능
 			Long userId = Long.valueOf(claims.getSubject());
 			String email = claims.get("email", String.class);
 			String nickname = claims.get("nickname", String.class);
 			debugLog("JWT Claims 파싱 성공 - userId: " + userId);
 
-			// 5) 권한 매핑 (예시: ROLE_USER)
-			var authorities  = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+			var authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+			CustomPrincipal principal = new CustomPrincipal(userId, email, nickname, authorities);
 
-			// 6)  UserDetails 대신 CustomPrincipal 생성
-			CustomPrincipal principal =
-				new CustomPrincipal(userId, email, nickname, authorities);
-
-			// 7) Authentication 객체 생성 & SecurityContext 에 저장
-			var authentication =
-				new UsernamePasswordAuthenticationToken(principal, null, authorities);
-
-			/*
-			 * 보안 컨텍스트에 방금 만든 authentication 객체를 저장
-			   → 이후 컨트롤러 단에서 @AuthenticationPrincipal 같은 방식으로 사용자 정보를 꺼낼 수 있다
-			   → 인증을 수동으로 완료 처리함
-			 */
+			var authentication = new UsernamePasswordAuthenticationToken(principal, null, authorities);
 			SecurityContextHolder.getContext().setAuthentication(authentication);
 			debugLog("SecurityContext 등록 완료 - principal: " + principal.getEmail());
 
 			debugLog("JWT 인증 완료. 다음 필터로 전달");
 			filterChain.doFilter(request, response);
-			// jwtProvider.getClaims() 에서 토큰 만료됐거나 위조된 경우 예외 발생
+
 		} catch (CustomException e) {
 			debugLog("JWT 검증 실패 - 이유: " + e.getMessage());
 			writeErrorResponse(response, e.getErrorCode().getStatus(), e.getMessage());
-		} catch(Exception e) {
+		} catch (Exception e) {
 			debugLog("검증 실패 - 이유: " + e.getMessage());
 			writeErrorResponse(response, ErrorCode.FAILED_AUTHORIZATION.getStatus(), e.getMessage());
 		}
 	}
 
-	// JWT 없거나 잘못된 경우 사용할 공통 메서드
-	private void writeErrorResponse(HttpServletResponse response, HttpStatusCode status, String message) throws
-		IOException {
-
+	// 오류 응답 반환 (JSON)
+	private void writeErrorResponse(HttpServletResponse response, HttpStatusCode status, String message)
+		throws IOException {
 		response.setStatus(status.value());
 		response.setContentType("application/json;charset=UTF-8");
 		response.getWriter().write(String.format("{\"status\":%d,\"message\":\"%s\"}", status.value(), message));
 	}
 
-	// 커스텀 디버깅 메시지용 메서드
+	// 디버그 로그
 	private void debugLog(String message) {
 		log.debug("[JwtFilter] {}", message);
 	}

--- a/src/main/java/com/study/petory/common/security/JwtFilter.java
+++ b/src/main/java/com/study/petory/common/security/JwtFilter.java
@@ -59,7 +59,24 @@ public class JwtFilter extends OncePerRequestFilter {
 
 		// 요청 URI
 		String url = request.getRequestURI();
-		debugLog("요청 URI: " + url);
+		String method = request.getMethod();
+		String servletPath = request.getServletPath();
+		String contextPath = request.getContextPath();
+		String fullUrl = request.getRequestURL().toString();
+
+		debugLog("요청 로그 확인 --------------------------");
+		debugLog("Method: " + method);
+		debugLog("Request URI: " + url);
+		debugLog("Servlet Path: " + servletPath);
+		debugLog("Context Path: " + contextPath);
+		debugLog("전체 URL: " + fullUrl);
+
+		// GET /owner-boards 하위 경로 모두 허용
+		if ("GET".equalsIgnoreCase(method) && url.startsWith("/owner-boards")) {
+			debugLog("GET /owner-boards 경로입니다. 필터 우회: " + url);
+			filterChain.doFilter(request, response);
+			return;
+		}
 
 		// 정적 리소스 또는 화이트리스트 우회
 		if (url.matches(".*(\\.html|\\.css|\\.js|\\.png|\\.jpg|\\.ico)$") || WHITELIST.contains(url)) {
@@ -84,7 +101,7 @@ public class JwtFilter extends OncePerRequestFilter {
 			}
 		}
 
-		// 3. 최종적으로 bearerJwt 가 null이면 인증 실패
+		// 3. 최종적으로 bearerJwt 가 null 이면 인증 실패
 		if (bearerJwt == null) {
 			debugLog("Authorization 헤더 없음. 필터 중단");
 			writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "Authorization 헤더가 존재하지 않습니다.");

--- a/src/main/java/com/study/petory/common/security/JwtProvider.java
+++ b/src/main/java/com/study/petory/common/security/JwtProvider.java
@@ -186,37 +186,39 @@ public class JwtProvider {
 	}
 
 	/*
-	 * Redis 에 이메일을 키로 하여 Refresh Token 을 저장
-	   → 키는 이메일(또는 사용자 ID), 값은 토큰
+	 * Redis 에 userId를 키로 하여 Refresh Token 을 저장
 	 * Redis TTL(Time-To-Live)은 7일 → 자동 만료
 	 */
-	public void storeRefreshToken(String email, String refreshToken) {
+	public void storeRefreshToken(Long userId, String refreshToken) {
 
 		long expireMillis = refreshTokenLife;
-
-		// TODO - RefreshToken 저장 Key 를 이메일 말고 userId로
-		loginRefreshToken.opsForValue().set(email, refreshToken, expireMillis, TimeUnit.MILLISECONDS);
+		loginRefreshToken.opsForValue().set(
+			String.valueOf(userId),
+			refreshToken,
+			expireMillis,
+			TimeUnit.MILLISECONDS
+		);
 	}
 
 	// 로그아웃 시 Redis 에서 해당 사용자의 Refresh Token 삭제
-	public void deleteRefreshToken(String email) {
+	public void deleteRefreshToken(Long userId) {
 
-		loginRefreshToken.delete(email);
+		loginRefreshToken.delete(String.valueOf(userId));
 	}
 
 	/*
 	 * Redis 에 저장된 토큰과 전달된 토큰이 일치하는지 검사
 	 * 유효하지 않거나 존재하지 않으면 false 반환
 	 */
-	public boolean isValidRefreshToken(String email, String refreshToken) {
+	public boolean isValidRefreshToken(Long userId, String refreshToken) {
 
-		String saved = loginRefreshToken.opsForValue().get(email);
-
+		String saved = loginRefreshToken.opsForValue().get(String.valueOf(userId));
 		return saved != null && saved.equals(refreshToken);
 	}
 
 	// 이메일 추출 메서드
 	public String getEmailFromToken(String token) {
+
 		Claims claims = parseRawToken(token);
 		return claims.get("email", String.class);
 	}

--- a/src/main/java/com/study/petory/domain/user/controller/AuthController.java
+++ b/src/main/java/com/study/petory/domain/user/controller/AuthController.java
@@ -12,8 +12,6 @@ import com.study.petory.common.response.CommonResponse;
 import com.study.petory.domain.user.dto.TokenResponseDto;
 import com.study.petory.domain.user.service.AuthService;
 
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -24,81 +22,40 @@ public class AuthController {
 
 	private final AuthService authService;
 
-	private static final String REFRESH_TOKEN_NAME = "refreshToken";
+	/**
+	 * [토큰 재발급]
+	 * Authorization 헤더에서 refreshToken 을 추출해 Redis 검증 후
+	 * AccessToken 과 새로운 RefreshToken 을 재발급
+	 * 새 RefreshToken 은 응답 본문에 포함 (쿠키 사용 안함)
+	 *
+	 * @param bearerRefreshToken : "Bearer {refreshToken}" 형식의 헤더
+	 * @return 새로 발급된 AccessToken + RefreshToken 포함 응답
+	 */
+	@PostMapping("/reissue")
+	public ResponseEntity<CommonResponse<TokenResponseDto>> reissue(
+		@RequestHeader("Authorization") String bearerRefreshToken
+	) {
 
-	// Authorization 헤더의 Bearer (재발급된)refreshToken 만으로 로그인
-	// @PostMapping("/login")
-	// public ResponseEntity<CommonResponse<TokenResponseDto>> login(
-	// 	@RequestHeader("Authorization") String bearerRefreshToken,
-	// 	HttpServletResponse response) {
-	//
-	// 	// AuthService.login 에서 새 토큰 발급
-	// 	TokenResponseDto tokens = authService.login(bearerRefreshToken);
-	//
-	// 	// refreshToken 쿠키로 재설정
-	// 	Cookie refreshCookie = new Cookie(REFRESH_TOKEN_NAME, tokens.getRefreshToken());
-	// 	refreshCookie.setPath("/");
-	// 	refreshCookie.setHttpOnly(true);
-	// 	refreshCookie.setSecure(true);
-	// 	refreshCookie.setMaxAge(7 * 24 * 60 * 60);  // 7일
-	// 	response.addCookie(refreshCookie);
-	//
-	// 	return CommonResponse.of(SuccessCode.USER_LOGIN, tokens);
-	// }
+		TokenResponseDto tokenResponseDto = authService.reissue(bearerRefreshToken);
+		return CommonResponse.of(SuccessCode.TOKEN_REISSUE, tokenResponseDto);
+	}
 
 	/**
-	 * 로그아웃 처리
-	 * AccessToken 을 블랙리스트에 등록
-	 * Redis 에서 RefreshToken 제거
-	 * 클라이언트의 RefreshToken 쿠키 제거
+	 * [로그아웃 처리]
+	 * AccessToken 을 블랙리스트에 등록하고,
+	 * Redis 에 저장된 RefreshToken 삭제
 	 *
-	 * @param bearerToken : "Bearer {token}" 형식의 인증 토큰
-	 * @param response : HttpServletResponse 객체 (쿠키 제거 위해 사용)
+	 * @param bearerToken : "Bearer {accessToken}" 형식의 헤더
+	 * @param response : (쿠키 방식일 경우 제거용)
 	 * @return 로그아웃 성공 메시지
 	 */
 	@DeleteMapping("/logout")
 	public ResponseEntity<CommonResponse<Object>> logout(
 		@RequestHeader("Authorization") String bearerToken,
-		HttpServletResponse response) {
+		HttpServletResponse response
+	) {
 
 		authService.logout(bearerToken);
-
-		// 클라이언트의 refreshToken 쿠키 제거 (MaxAge = 0)
-		Cookie deleteCookie = new Cookie(REFRESH_TOKEN_NAME, null);
-		deleteCookie.setPath("/");
-		deleteCookie.setMaxAge(0);
-		deleteCookie.setHttpOnly(true);
-		deleteCookie.setSecure(true);  // HTTPS 환경에서만 전송
-		response.addCookie(deleteCookie);
-
 		return CommonResponse.of(SuccessCode.USER_LOGOUT);
-	}
-
-	/**
-	 * RefreshToken 쿠키 기반으로 AccessToken 재발급
-	 * Redis 에 저장된 RefreshToken 과 쿠키 비교
-	 * AccessToken + 새 RefreshToken 발급
-	 * 새 RefreshToken 을 쿠키로 재설정
-	 *
-	 * @param request : HttpServletRequest (쿠키 접근)
-	 * @param response : HttpServletResponse (새 쿠키 설정)
-	 * @return 새로 발급된 AccessToken + RefreshToken 포함 응답
-	 */
-	@PostMapping("/reissue")
-	public ResponseEntity<CommonResponse<TokenResponseDto>> reissue(
-		HttpServletRequest request,
-		HttpServletResponse response) {
-
-		TokenResponseDto tokenResponseDto = authService.reissue(request);
-
-		// 새 refreshToken 을 HttpOnly 쿠키로 설정
-		Cookie refreshCookie = new Cookie(REFRESH_TOKEN_NAME, tokenResponseDto.getRefreshToken());
-		refreshCookie.setPath("/");
-		refreshCookie.setHttpOnly(true);
-		refreshCookie.setSecure(true);  // HTTPS 환경
-		refreshCookie.setMaxAge(7 * 24 * 60 * 60);  // 7일
-		response.addCookie(refreshCookie);
-
-		return CommonResponse.of(SuccessCode.TOKEN_REISSUE, tokenResponseDto);
 	}
 }

--- a/src/main/java/com/study/petory/domain/user/controller/UserController.java
+++ b/src/main/java/com/study/petory/domain/user/controller/UserController.java
@@ -5,7 +5,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/study/petory/domain/user/service/AuthService.java
+++ b/src/main/java/com/study/petory/domain/user/service/AuthService.java
@@ -41,7 +41,7 @@ public class AuthService {
 			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
 		if (savedUser.getId() == null) {
-			throw new IllegalStateException("사용자 정보를 저장했지만 ID가 생성되지 않았습니다. DB 설정을 확인하세요.");
+			throw new CustomException(ErrorCode.USER_ID_NOT_GENERATED);
 		}
 
 		String accessToken = jwtProvider.createAccessToken(savedUser.getId(), savedUser.getEmail(),

--- a/src/main/java/com/study/petory/domain/user/service/AuthService.java
+++ b/src/main/java/com/study/petory/domain/user/service/AuthService.java
@@ -1,6 +1,5 @@
 package com.study.petory.domain.user.service;
 
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -13,10 +12,6 @@ import com.study.petory.common.security.JwtProvider;
 import com.study.petory.domain.user.dto.TokenResponseDto;
 import com.study.petory.domain.user.entity.User;
 import com.study.petory.domain.user.repository.UserRepository;
-
-import io.jsonwebtoken.Claims;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 
 @Service
 public class AuthService {
@@ -35,14 +30,13 @@ public class AuthService {
 		this.loginRefreshToken = loginRefreshToken;
 	}
 
-	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
-
 	/*
+	 * [토큰 발급]
 	 * Google OAuth2 로그인 성공 시 토큰 발급
+	 * Redis 에 refreshToken 저장 (userId 기준 키)
 	 */
 	public TokenResponseDto issueToken(User user) {
 
-		// 기존 유저 조회 또는 저장 (없으면 저장 후 반환)
 		User savedUser = userRepository.findByEmail(user.getEmail())
 			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
@@ -50,118 +44,61 @@ public class AuthService {
 			throw new IllegalStateException("사용자 정보를 저장했지만 ID가 생성되지 않았습니다. DB 설정을 확인하세요.");
 		}
 
-		// Access Token: 사용자 정보를 포함해 짧은 생명주기로 발급
 		String accessToken = jwtProvider.createAccessToken(savedUser.getId(), savedUser.getEmail(),
 			savedUser.getNickname());
-
-		// Refresh Token: ID만 기반으로 더 긴 생명주기로 발급
 		String refreshToken = jwtProvider.createRefreshToken(savedUser.getId());
 
-		// Redis 에 Refresh Token 을 {email}키로 저장
-		jwtProvider.storeRefreshToken(savedUser.getEmail(), refreshToken);
+		jwtProvider.storeRefreshToken(savedUser.getId(), refreshToken);
 
 		return new TokenResponseDto(accessToken, refreshToken);
 	}
 
-	// 헤더의 Bearer refreshToken 만으로 로그인(토큰 재발급) 처리
-	public TokenResponseDto login(String bearerRefreshToken) {
-		// 1) "Bearer " 제거
-		String rawRefreshToken = jwtProvider.subStringToken(bearerRefreshToken);
-
-		// 2) prefix 없는 JWT 파싱하여 Claims 얻기
-		Claims claims = jwtProvider.parseRawToken(rawRefreshToken);
-
-		// 3) 토큰에서 userId 추출
-		Long userId = Long.valueOf(claims.getSubject());
-
-		// 4) DB에서 사용자 조회
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-		// 5) 새로운 AccessToken / RefreshToken 발급
-		String newAccessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail(), user.getNickname());
-		String newRefreshToken = jwtProvider.createRefreshToken(user.getId());
-
-		// 6) Redis에 저장된 이전 RT 삭제 후 신규 RT 저장
-		jwtProvider.deleteRefreshToken(user.getEmail());
-		jwtProvider.storeRefreshToken(user.getEmail(), newRefreshToken);
-
-		return new TokenResponseDto(newAccessToken, newRefreshToken);
-	}
-
 	/*
-	 * 로그아웃: Access Token 블랙리스트 처리 + Refresh Token 삭제
+	 * [로그아웃 처리]
+	 * AccessToken 을 블랙리스트 등록
+	 * Redis 에 저장된 RefreshToken 제거
 	 */
 	public void logout(String accessToken) {
 
-		// 접두어 "Bearer " 제거 후 토큰 문자열만 추출
 		String pureToken = jwtProvider.subStringToken(accessToken);
+		Long userId = Long.valueOf(jwtProvider.getClaims(accessToken).getSubject());
 
-		// 토큰에서 추출한 이메일
-		String email = jwtProvider.getEmailFromToken(pureToken);
-
-		// 토큰 만료 시간 계산
 		long expiration = jwtProvider.getClaims(accessToken).getExpiration().getTime() - System.currentTimeMillis();
 
-		// Redis 에 "BLACKLIST_{token}" 키로 남은 유효시간만큼 저장
-		loginRefreshToken
-			.opsForValue()
+		loginRefreshToken.opsForValue()
 			.set("BLACKLIST_" + pureToken, "logout", expiration, TimeUnit.MILLISECONDS);
 
-		// Refresh Token 삭제
-		jwtProvider.deleteRefreshToken(email);
+		jwtProvider.deleteRefreshToken(userId);
 	}
 
 	/*
-	 * RefreshToken 을 쿠키에서 읽고 AccessToken 재발급
+	 * [토큰 재발급]
+	 * Authorization 헤더로 전달된 refreshToken 기반으로 AccessToken 재발급
+	 * Redis 의 refreshToken 과 일치하는지 검증
 	 */
-	public TokenResponseDto reissue(HttpServletRequest request) {
+	public TokenResponseDto reissue(String bearerRefreshToken) {
 
-		// 쿠키에서 RefreshToken 추출
-		String refreshToken = extractRefreshTokenFromCookie(request);
+		// Bearer 접두어 제거
+		String refreshToken = jwtProvider.subStringToken(bearerRefreshToken);
 
-		// 토큰에서 추출한 이메일
-		String email = jwtProvider.getEmailFromToken(refreshToken);
+		// JWT Claims 에서 userId 추출
+		Long userId = Long.valueOf(jwtProvider.getClaims(refreshToken).getSubject());
 
-		// Redis 에 저장된 Refresh Token 과 일치하는지, 만료되지 않았는지 검증
-		if (!jwtProvider.isValidRefreshToken(email, refreshToken)) {
+		// Redis 에 저장된 RefreshToken 과 비교
+		if (!jwtProvider.isValidRefreshToken(userId, refreshToken)) {
 			throw new CustomException(ErrorCode.INVALID_TOKEN);
 		}
 
-		User user = userRepository.findByEmail(email)
+		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-		// 새로운 AccessToken + RefreshToken 생성
 		String newAccessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail(), user.getNickname());
 		String newRefreshToken = jwtProvider.createRefreshToken(user.getId());
 
-		// 기존 RefreshToken 삭제 후 새 토큰 Redis 에 재저장
-		jwtProvider.deleteRefreshToken(email);
-		jwtProvider.storeRefreshToken(email, newRefreshToken);
+		// Redis 에 기존 RefreshToken 삭제 및 신규 저장
+		jwtProvider.deleteRefreshToken(user.getId());
+		jwtProvider.storeRefreshToken(user.getId(), newRefreshToken);
 
-		// refreshToken 은 HttpOnly 쿠키로 재설정 (Controller 책임)
-		return new TokenResponseDto(newAccessToken, newRefreshToken); // refreshToken 은 Controller 에서 쿠키로 설정
-	}
-
-	/*
-	 * 쿠키에서 RefreshToken 추출
-	 */
-	private String extractRefreshTokenFromCookie(HttpServletRequest request) {
-
-		if (request.getCookies() == null) {
-			throw new CustomException(ErrorCode.INVALID_TOKEN);
-		}
-
-		for (Cookie cookie : request.getCookies()) {
-			if (REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
-				try {
-					return java.net.URLDecoder.decode(cookie.getValue(),
-						StandardCharsets.UTF_8);
-				} catch (Exception e) {
-					throw new CustomException(ErrorCode.INVALID_TOKEN);
-				}
-			}
-		}
-		throw new CustomException(ErrorCode.INVALID_TOKEN);
+		return new TokenResponseDto(newAccessToken, newRefreshToken);
 	}
 }

--- a/src/main/java/com/study/petory/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/study/petory/domain/user/service/CustomOAuth2UserService.java
@@ -10,6 +10,8 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.study.petory.common.exception.CustomException;
+import com.study.petory.common.exception.enums.ErrorCode;
 import com.study.petory.domain.user.entity.Role;
 import com.study.petory.domain.user.entity.User;
 import com.study.petory.domain.user.entity.UserPrivateInfo;
@@ -39,7 +41,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 		// 4. 이메일이 없으면 예외 발생 → 회원 식별이 불가하므로
 		if (email == null || email.isBlank()) {
-			throw new IllegalArgumentException("이메일 정보가 제공되지 않았습니다.");
+			throw new CustomException(ErrorCode.OAUTH2_EMAIL_NOT_FOUND);
 		}
 
 		// 5. 사용자 정보가 DB에 존재하지 않으면 새로 생성


### PR DESCRIPTION
## #️⃣이슈 번호

close #68 


## 📝작업 상세 내용

- [ ] Security, Filter - 비회원 전용 URL 및 메서드 경로 설정
- [x] Redis에 Refresh 토큰 저장할 때 email 대신 userId로 키값 변경
- [x] Refresh 토큰을 쿠키에 담는 방식에서 헤더에 담는 방식으로 변경


## 💬리뷰 요구사항 (선택)



