### PR TITLE
Refactor/98 question

### DIFF
--- a/src/main/java/com/study/petory/common/exception/enums/ErrorCode.java
+++ b/src/main/java/com/study/petory/common/exception/enums/ErrorCode.java
@@ -48,6 +48,10 @@ public enum ErrorCode implements BaseCode {
 	// DailyQna
 	DAILY_QNA_NOT_FOUND(HttpStatus.NOT_FOUND, "질의 응답이 존재하지 않습니다."),
 	ALREADY_WRITTEN_TODAY(HttpStatus.BAD_REQUEST, "오늘은 이미 작성하였습니다."),
+	DAILY_QNA_IS_HIDDEN(HttpStatus.BAD_REQUEST, "이미 숨겨진 질문입니다."),
+	DAILY_QNA_IS_NOT_HIDDEN(HttpStatus.BAD_REQUEST, "숨겨진 질문이 아닙니다."),
+	DAILY_QNA_IS_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 질문입니다."),
+	DAILY_QNA_IS_NOT_DELETED(HttpStatus.BAD_REQUEST, "삭제된 질문이 아닙니다."),
 
 	// Faq
 	FAQ_QNA_NOT_FOUND(HttpStatus.NOT_FOUND, "자주 찾는 질문은 존재하지 않습니다."),
@@ -80,9 +84,11 @@ public enum ErrorCode implements BaseCode {
 	// Question
 	QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "질문이 존재하지 않습니다."),
 	DATE_IS_EXIST(HttpStatus.CONFLICT, "해당 날짜에는 질문이 이미 존재합니다."),
+	TODAY_QUESTION_IS_DEACTIVATED(HttpStatus.BAD_REQUEST, "관리자에 의해 비활성화된 질문입니다."),
 	QUESTION_IS_DEACTIVATED(HttpStatus.BAD_REQUEST, "이미 비활성화된 질문입니다."),
 	QUESTION_IS_NOT_DEACTIVATED(HttpStatus.BAD_REQUEST, "비활성화된 질문이 아닙니다."),
-	TODAY_QUESTION_IS_DEACTIVATED(HttpStatus.BAD_REQUEST, "관리자에 의해 비활성화된 질문입니다."),
+	QUESTION_IS_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 질문입니다."),
+	QUESTION_IS_NOT_DELETED(HttpStatus.BAD_REQUEST, "삭제된 질문이 아닙니다."),
 
 	// OwnerBoardComment
 	OWNER_BOARD_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다."),

--- a/src/main/java/com/study/petory/domain/album/controller/AlbumController.java
+++ b/src/main/java/com/study/petory/domain/album/controller/AlbumController.java
@@ -111,12 +111,12 @@ public class AlbumController {
 		@AuthenticationPrincipal CustomPrincipal currentUser,
 		@PathVariable Long albumId
 	) {
-		return CommonResponse.of(SuccessCode.FOUND, albumService.findOneAlbum(currentUser.getId(), albumId));
+		return CommonResponse.of(SuccessCode.FOUND, albumService.findOneAlbum(currentUser, albumId));
 	}
 
 	/**
 	 * 앨범 수정
-	 * @param currentUser			앨범을 생성한 유저
+	 * @param currentUser	앨범을 생성한 유저
 	 * @param albumId		수정할 앨범 id
 	 * @param request		수정할 내용
 	 * @return	CommonResponse 성공 메세지, data: null

--- a/src/main/java/com/study/petory/domain/album/repository/AlbumCustomRepository.java
+++ b/src/main/java/com/study/petory/domain/album/repository/AlbumCustomRepository.java
@@ -14,5 +14,7 @@ public interface AlbumCustomRepository {
 	Optional<Album> findOneAlbumByUser(boolean showOnlyPublic, Long albumId);
 
 	boolean existTodayAlbum(Long userId);
+
+	boolean isUserAlbum(Long userId, Long albumId);
 }
 

--- a/src/main/java/com/study/petory/domain/album/repository/AlbumCustomRepositoryImpl.java
+++ b/src/main/java/com/study/petory/domain/album/repository/AlbumCustomRepositoryImpl.java
@@ -137,4 +137,17 @@ public class AlbumCustomRepositoryImpl implements AlbumCustomRepository {
 			)
 			.fetchFirst() != null;
 	}
+
+	@Override
+	public boolean isUserAlbum(Long userId, Long albumId) {
+		return jpaQueryFactory
+			.selectOne()
+			.from(qAlbum)
+			.join(qUser).on(qUser.id.eq(qAlbum.user.id)).fetchJoin()
+			.where(
+				qAlbum.id.eq(albumId),
+				qAlbum.user.id.eq(userId)
+			)
+			.fetchFirst() != null;
+	}
 }

--- a/src/main/java/com/study/petory/domain/album/service/AlbumImageServiceImpl.java
+++ b/src/main/java/com/study/petory/domain/album/service/AlbumImageServiceImpl.java
@@ -63,6 +63,9 @@ public class AlbumImageServiceImpl extends AbstractImageService<AlbumImage> {
 		if (userRole.contains(Role.USER)) {
 			imageSize = 1;
 		}
+		if (userRole.contains(Role.ADMIN)) {
+			imageSize = 5;
+		}
 		return imageSize;
 	}
 }

--- a/src/main/java/com/study/petory/domain/album/service/AlbumService.java
+++ b/src/main/java/com/study/petory/domain/album/service/AlbumService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.study.petory.common.security.CustomPrincipal;
 import com.study.petory.domain.album.dto.request.AlbumCreateRequestDto;
 import com.study.petory.domain.album.dto.request.AlbumUpdateRequestDto;
 import com.study.petory.domain.album.dto.request.AlbumVisibilityUpdateRequestDto;
@@ -20,7 +21,7 @@ public interface AlbumService {
 
 	Page<AlbumGetAllResponseDto> findAllAlbum(boolean showOnlyPublic, Long userId, Pageable pageable);
 
-	AlbumGetOneResponseDto findOneAlbum(Long userId, Long albumId);
+	AlbumGetOneResponseDto findOneAlbum(CustomPrincipal currentUser, Long albumId);
 
 	void updateAlbum(Long userId, Long albumId, AlbumUpdateRequestDto request);
 

--- a/src/main/java/com/study/petory/domain/album/service/AlbumServiceImpl.java
+++ b/src/main/java/com/study/petory/domain/album/service/AlbumServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.study.petory.common.exception.CustomException;
 import com.study.petory.common.exception.enums.ErrorCode;
+import com.study.petory.common.security.CustomPrincipal;
 import com.study.petory.domain.album.dto.request.AlbumCreateRequestDto;
 import com.study.petory.domain.album.dto.request.AlbumUpdateRequestDto;
 import com.study.petory.domain.album.dto.request.AlbumVisibilityUpdateRequestDto;
@@ -77,11 +78,13 @@ public class AlbumServiceImpl implements AlbumService {
 
 	// 앨범 단일 조회
 	@Override
-	public AlbumGetOneResponseDto findOneAlbum(Long userId, Long albumId) {
+	public AlbumGetOneResponseDto findOneAlbum(CustomPrincipal currentUser, Long albumId) {
 		boolean showOnlyPublic = true;
-		if (userId != null) {
+
+		if (currentUser != null && albumRepository.isUserAlbum(currentUser.getId(), albumId)) {
 			showOnlyPublic = false;
 		}
+
 		return AlbumGetOneResponseDto.from(findAlbumByAlbumId(showOnlyPublic, albumId));
 	}
 

--- a/src/main/java/com/study/petory/domain/dailyQna/controller/QuestionController.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/controller/QuestionController.java
@@ -78,7 +78,7 @@ public class QuestionController {
 	@GetMapping("/all")
 	@PreAuthorize("hasRole('ADMIN')")
 	public ResponseEntity<CommonResponse<Page<QuestionGetAllResponseDto>>> getAllQuestion(
-		@PageableDefault(size = 50, sort = "data", direction = Sort.Direction.ASC) Pageable pageable
+		@PageableDefault(size = 50, sort = "date", direction = Sort.Direction.ASC) Pageable pageable
 	) {
 		return CommonResponse.of(SuccessCode.FOUND, questionService.findAllQuestion(pageable));
 	}

--- a/src/main/java/com/study/petory/domain/dailyQna/controller/QuestionController.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/controller/QuestionController.java
@@ -27,10 +27,10 @@ import com.study.petory.domain.dailyQna.dto.request.DailyQnaUpdateRequestDto;
 import com.study.petory.domain.dailyQna.dto.request.QuestionCreateRequestDto;
 import com.study.petory.domain.dailyQna.dto.request.QuestionUpdateRequestDto;
 import com.study.petory.domain.dailyQna.dto.response.DailyQnaGetDeletedResponse;
-import com.study.petory.domain.dailyQna.dto.response.DailyQnaGetHiddenResponse;
+import com.study.petory.domain.dailyQna.dto.response.DailyQnaGetHiddenResponseDto;
 import com.study.petory.domain.dailyQna.dto.response.DailyQnaGetResponseDto;
 import com.study.petory.domain.dailyQna.dto.response.QuestionGetAllResponseDto;
-import com.study.petory.domain.dailyQna.dto.response.QuestionGetDeletedResponse;
+import com.study.petory.domain.dailyQna.dto.response.QuestionGetDeletedResponseDto;
 import com.study.petory.domain.dailyQna.dto.response.QuestionGetInactiveResponseDto;
 import com.study.petory.domain.dailyQna.dto.response.QuestionGetOneResponseDto;
 import com.study.petory.domain.dailyQna.dto.response.QuestionGetTodayResponseDto;
@@ -78,7 +78,7 @@ public class QuestionController {
 	@GetMapping("/all")
 	@PreAuthorize("hasRole('ADMIN')")
 	public ResponseEntity<CommonResponse<Page<QuestionGetAllResponseDto>>> getAllQuestion(
-		@PageableDefault(size = 50, sort = "date", direction = Sort.Direction.ASC) Pageable pageable
+		@PageableDefault(size = 50, sort = "id", direction = Sort.Direction.ASC) Pageable pageable
 	) {
 		return CommonResponse.of(SuccessCode.FOUND, questionService.findAllQuestion(pageable));
 	}
@@ -185,7 +185,7 @@ public class QuestionController {
 	 */
 	@GetMapping("/deleted")
 	@PreAuthorize("hasRole('ADMIN')")
-	public ResponseEntity<CommonResponse<Page<QuestionGetDeletedResponse>>> getQuestionByDeleted(
+	public ResponseEntity<CommonResponse<Page<QuestionGetDeletedResponseDto>>> getQuestionByDeleted(
 		@PageableDefault(size = 50, sort = "deletedAt", direction = Sort.Direction.ASC) Pageable pageable
 	) {
 		return CommonResponse.of(SuccessCode.FOUND, questionService.findQuestionByDeleted(pageable));
@@ -280,7 +280,7 @@ public class QuestionController {
 	 */
 	@GetMapping("/daily-qnas/hide")
 	@PreAuthorize("hasRole('USER')")
-	public ResponseEntity<CommonResponse<Page<DailyQnaGetHiddenResponse>>> getHiddenDailyQna(
+	public ResponseEntity<CommonResponse<Page<DailyQnaGetHiddenResponseDto>>> getHiddenDailyQna(
 		@AuthenticationPrincipal CustomPrincipal currentUser,
 		@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
 	) {

--- a/src/main/java/com/study/petory/domain/dailyQna/controller/QuestionController.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/controller/QuestionController.java
@@ -78,7 +78,7 @@ public class QuestionController {
 	@GetMapping("/all")
 	@PreAuthorize("hasRole('ADMIN')")
 	public ResponseEntity<CommonResponse<Page<QuestionGetAllResponseDto>>> getAllQuestion(
-		@PageableDefault(size = 50, sort = "id", direction = Sort.Direction.ASC) Pageable pageable
+		@PageableDefault(size = 50, sort = "data", direction = Sort.Direction.ASC) Pageable pageable
 	) {
 		return CommonResponse.of(SuccessCode.FOUND, questionService.findAllQuestion(pageable));
 	}

--- a/src/main/java/com/study/petory/domain/dailyQna/dto/request/QuestionCreateRequestDto.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/dto/request/QuestionCreateRequestDto.java
@@ -12,7 +12,7 @@ public class QuestionCreateRequestDto {
 
 	@NotBlank
 	@Size(max = 85, message = "85글자 이하로 입력해주세요.")
-	private String question;
+	private String content;
 
 	@NotBlank
 	@Size(max = 10, message = "10글자 이하로 입력해주세요.")

--- a/src/main/java/com/study/petory/domain/dailyQna/dto/request/QuestionUpdateRequestDto.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/dto/request/QuestionUpdateRequestDto.java
@@ -12,7 +12,7 @@ public class QuestionUpdateRequestDto {
 
 	@NotBlank
 	@Size(max = 85, message = "85글자 이하로 입력해주세요.")
-	private String question;
+	private String content;
 
 	@NotBlank
 	@Size(max = 10, message = "10글자 이하로 입력해주세요.")

--- a/src/main/java/com/study/petory/domain/dailyQna/dto/response/DailyQnaGetHiddenResponseDto.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/dto/response/DailyQnaGetHiddenResponseDto.java
@@ -7,7 +7,7 @@ import com.study.petory.domain.dailyQna.entity.DailyQna;
 import lombok.Getter;
 
 @Getter
-public class DailyQnaGetHiddenResponse {
+public class DailyQnaGetHiddenResponseDto {
 
 	private final String answer;
 
@@ -15,14 +15,14 @@ public class DailyQnaGetHiddenResponse {
 
 	private final LocalDateTime hiddenTime;
 
-	private DailyQnaGetHiddenResponse(String answer, LocalDateTime createdAt, LocalDateTime hiddenTime) {
+	private DailyQnaGetHiddenResponseDto(String answer, LocalDateTime createdAt, LocalDateTime hiddenTime) {
 		this.answer = answer;
 		this.createdAt = createdAt;
 		this.hiddenTime = hiddenTime;
 	}
 
-	public static DailyQnaGetHiddenResponse from(DailyQna dailyQna) {
-		return new DailyQnaGetHiddenResponse(
+	public static DailyQnaGetHiddenResponseDto from(DailyQna dailyQna) {
+		return new DailyQnaGetHiddenResponseDto(
 			dailyQna.getAnswer(),
 			dailyQna.getCreatedAt(),
 			dailyQna.getUpdatedAt()

--- a/src/main/java/com/study/petory/domain/dailyQna/dto/response/QuestionGetAllResponseDto.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/dto/response/QuestionGetAllResponseDto.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 @Getter
 public class QuestionGetAllResponseDto {
 
-	private final String question;
+	private final String content;
 
 	private final String date;
 
@@ -21,8 +21,8 @@ public class QuestionGetAllResponseDto {
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private LocalDateTime updatedAt;
 
-	private QuestionGetAllResponseDto(String question, String date, QuestionStatus questionStatus, LocalDateTime updatedAt) {
-		this.question = question;
+	private QuestionGetAllResponseDto(String content, String date, QuestionStatus questionStatus, LocalDateTime updatedAt) {
+		this.content = content;
 		this.date = date;
 		if (questionStatus == QuestionStatus.INACTIVE) {
 			this.questionStatus = questionStatus;
@@ -32,7 +32,7 @@ public class QuestionGetAllResponseDto {
 
 	public static QuestionGetAllResponseDto from(Question question) {
 		return new QuestionGetAllResponseDto(
-			question.getQuestion(),
+			question.getContent(),
 			question.getDate(),
 			question.getQuestionStatus(),
 			question.getUpdatedAt()

--- a/src/main/java/com/study/petory/domain/dailyQna/dto/response/QuestionGetDeletedResponseDto.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/dto/response/QuestionGetDeletedResponseDto.java
@@ -7,23 +7,23 @@ import com.study.petory.domain.dailyQna.entity.Question;
 import lombok.Getter;
 
 @Getter
-public class QuestionGetDeletedResponse {
+public class QuestionGetDeletedResponseDto {
 
-	private final String question;
+	private final String content;
 
 	private final String date;
 
 	private final LocalDateTime deletedAt;
 
-	private QuestionGetDeletedResponse(String question, String date, LocalDateTime deletedAt) {
-		this.question = question;
+	private QuestionGetDeletedResponseDto(String content, String date, LocalDateTime deletedAt) {
+		this.content = content;
 		this.date = date;
 		this.deletedAt = deletedAt;
 	}
 
-	public static QuestionGetDeletedResponse from(Question question) {
-		return new QuestionGetDeletedResponse(
-			question.getQuestion(),
+	public static QuestionGetDeletedResponseDto from(Question question) {
+		return new QuestionGetDeletedResponseDto(
+			question.getContent(),
 			question.getDate(),
 			question.getDeletedAt()
 		);

--- a/src/main/java/com/study/petory/domain/dailyQna/dto/response/QuestionGetInactiveResponseDto.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/dto/response/QuestionGetInactiveResponseDto.java
@@ -9,21 +9,21 @@ import lombok.Getter;
 @Getter
 public class QuestionGetInactiveResponseDto {
 
-	private final String question;
+	private final String content;
 
 	private final String date;
 
 	private final LocalDateTime inactiveTime;
 
-	private QuestionGetInactiveResponseDto(String question, String date, LocalDateTime inactiveTime) {
-		this.question = question;
+	private QuestionGetInactiveResponseDto(String content, String date, LocalDateTime inactiveTime) {
+		this.content = content;
 		this.date = date;
 		this.inactiveTime = inactiveTime;
 	}
 
 	public static QuestionGetInactiveResponseDto from(Question question) {
 		return new QuestionGetInactiveResponseDto(
-			question.getQuestion(),
+			question.getContent(),
 			question.getDate(),
 			question.getUpdatedAt()
 		);

--- a/src/main/java/com/study/petory/domain/dailyQna/dto/response/QuestionGetOneResponseDto.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/dto/response/QuestionGetOneResponseDto.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 @Getter
 public class QuestionGetOneResponseDto {
 
-	private final String question;
+	private final String content;
 
 	private final String date;
 
@@ -21,8 +21,9 @@ public class QuestionGetOneResponseDto {
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private LocalDateTime updatedAt;
 
-	private QuestionGetOneResponseDto(String question, String date, QuestionStatus questionStatus, LocalDateTime updatedAt) {
-		this.question = question;
+	private QuestionGetOneResponseDto(String content, String date, QuestionStatus questionStatus,
+		LocalDateTime updatedAt) {
+		this.content = content;
 		this.date = date;
 		if (questionStatus == QuestionStatus.INACTIVE) {
 			this.questionStatus = questionStatus;
@@ -32,7 +33,7 @@ public class QuestionGetOneResponseDto {
 
 	public static QuestionGetOneResponseDto from(Question question) {
 		return new QuestionGetOneResponseDto(
-			question.getQuestion(),
+			question.getContent(),
 			question.getDate(),
 			question.getQuestionStatus(),
 			question.getUpdatedAt()

--- a/src/main/java/com/study/petory/domain/dailyQna/dto/response/QuestionGetTodayResponseDto.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/dto/response/QuestionGetTodayResponseDto.java
@@ -1,7 +1,6 @@
 package com.study.petory.domain.dailyQna.dto.response;
 
 import com.study.petory.domain.dailyQna.entity.Question;
-import com.study.petory.domain.dailyQna.entity.QuestionStatus;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,18 +9,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(force = true)
 public class QuestionGetTodayResponseDto {
 
-	private final String question;
+	private final String content;
 
 	private final String date;
 
-	private QuestionGetTodayResponseDto(String question, String date) {
-		this.question = question;
+	private QuestionGetTodayResponseDto(String content, String date) {
+		this.content = content;
 		this.date = date;
 	}
 
 	public static QuestionGetTodayResponseDto from(Question question) {
 		return new QuestionGetTodayResponseDto(
-			question.getQuestion(),
+			question.getContent(),
 			question.getDate()
 		);
 	}

--- a/src/main/java/com/study/petory/domain/dailyQna/entity/Question.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/entity/Question.java
@@ -25,7 +25,7 @@ public class Question extends TimeFeatureBasedEntity {
 	private Long id;
 
 	@Column(nullable = false)
-	private String question;
+	private String content;
 
 	@Column(nullable = false, unique = true, length = 10)
 	private String date;
@@ -35,14 +35,14 @@ public class Question extends TimeFeatureBasedEntity {
 	private QuestionStatus questionStatus;
 
 	@Builder
-	public Question(String question, String date, QuestionStatus questionStatus) {
-		this.question = question;
+	public Question(String content, String date, QuestionStatus questionStatus) {
+		this.content = content;
 		this.date = date;
 		this.questionStatus = questionStatus;
 	}
 
 	public void update(String question, String date) {
-		this.question = question;
+		this.content = question;
 		this.date = date;
 	}
 

--- a/src/main/java/com/study/petory/domain/dailyQna/repository/DailyQnaCustomRepository.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/repository/DailyQnaCustomRepository.java
@@ -7,16 +7,17 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.study.petory.domain.dailyQna.entity.DailyQna;
+import com.study.petory.domain.dailyQna.entity.DailyQnaStatus;
 
 public interface DailyQnaCustomRepository {
 
-	Optional<DailyQna> findDailyQnaByActive(Long dailyQnaId);
-
-	Page<DailyQna> findDailyQnaByHidden(Long userId, Pageable pageable);
-
-	Page<DailyQna> findDailyQnaByDeleted(Long userId, Pageable pageable);
-
 	boolean isDailyQnaToday(Long userId, Long questionId);
 
+	Optional<DailyQna> findDailyQnaByStatusAndId(List<DailyQnaStatus> statusList, Long dailyQnaId);
+
 	List<DailyQna> findDailyQna(Long userId, Long questionId);
+
+	Page<DailyQna> findDailyQnaPageByStatus(List<DailyQnaStatus> statusList, Long userId, Pageable pageable);
+
+	Optional<DailyQnaStatus> findDailyQnaStatusById(Long dailyQnaId);
 }

--- a/src/main/java/com/study/petory/domain/dailyQna/repository/DailyQnaCustomRepositoryImpl.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/repository/DailyQnaCustomRepositoryImpl.java
@@ -7,8 +7,14 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.study.petory.domain.dailyQna.entity.DailyQna;
 import com.study.petory.domain.dailyQna.entity.DailyQnaStatus;
@@ -28,87 +34,9 @@ public class DailyQnaCustomRepositoryImpl implements DailyQnaCustomRepository {
 
 	private final QUser qUser = QUser.user;
 
-	private final QQuestion qQuestion = QQuestion.question1;
+	private final QQuestion qQuestion = QQuestion.question;
 
-	@Override
-	public List<DailyQna> findDailyQna(Long userId, Long questionId) {
-		return jpaQueryFactory
-			.selectFrom(qDailyQna)
-			.join(qDailyQna.user, qUser).fetchJoin()
-			.join(qDailyQna.question, qQuestion).fetchJoin()
-			.where(
-				qDailyQna.user.id.eq(userId),
-				qDailyQna.question.id.eq(questionId),
-				qDailyQna.dailyQnaStatus.eq(DailyQnaStatus.ACTIVE)
-			)
-			.orderBy(qDailyQna.createdAt.desc())
-			.fetch();
-	}
-
-	@Override
-	public Optional<DailyQna> findDailyQnaByActive(Long dailyQnaId) {
-		return jpaQueryFactory
-			.selectFrom(qDailyQna)
-			.where(
-				qDailyQna.id.eq(dailyQnaId),
-				qDailyQna.dailyQnaStatus.eq(DailyQnaStatus.ACTIVE)
-			)
-			.stream().findAny();
-	}
-
-	@Override
-	public Page<DailyQna> findDailyQnaByHidden(Long userId, Pageable pageable) {
-		List<DailyQna> dailyQnaList = jpaQueryFactory
-			.selectFrom(qDailyQna)
-			.join(qDailyQna.user, qUser).fetchJoin()
-			.where(
-				qDailyQna.user.id.eq(userId),
-				qDailyQna.dailyQnaStatus.eq(DailyQnaStatus.HIDDEN)
-			)
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
-
-		Long total = jpaQueryFactory
-			.select(qDailyQna.count())
-			.from(qDailyQna)
-			.where(
-				qDailyQna.user.id.eq(userId),
-				qDailyQna.dailyQnaStatus.eq(DailyQnaStatus.HIDDEN)
-			)
-			.fetchOne();
-		if (total == null) {
-			total = 0L;
-		}
-		return new PageImpl<>(dailyQnaList, pageable, total);
-	}
-
-	@Override
-	public Page<DailyQna> findDailyQnaByDeleted(Long userId, Pageable pageable) {
-		List<DailyQna> dailyQnaList = jpaQueryFactory
-			.selectFrom(qDailyQna)
-			.join(qDailyQna.user, qUser).fetchJoin()
-			.where(
-				qDailyQna.user.id.eq(userId),
-				qDailyQna.dailyQnaStatus.eq(DailyQnaStatus.DELETED)
-			)
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
-
-		Long total = jpaQueryFactory
-			.select(qDailyQna.count())
-			.from(qDailyQna)
-			.where(
-				qDailyQna.user.id.eq(userId),
-				qDailyQna.dailyQnaStatus.eq(DailyQnaStatus.DELETED)
-			)
-			.fetchOne();
-		if (total == null) {
-			total = 0L;
-		}
-		return new PageImpl<>(dailyQnaList, pageable, total);
-	}
+	private final PathBuilder pathBuilder = new PathBuilder<>(DailyQna.class, "dailyQna");
 
 	@Override
 	public boolean isDailyQnaToday(Long userId, Long questionId) {
@@ -125,5 +53,100 @@ public class DailyQnaCustomRepositoryImpl implements DailyQnaCustomRepository {
 				)
 			)
 			.fetchFirst() != null;
+	}
+
+	@Override
+	public Optional<DailyQna> findDailyQnaByStatusAndId(List<DailyQnaStatus> statusList, Long dailyQnaId) {
+		BooleanBuilder status = new BooleanBuilder();
+
+		if (statusList.contains(DailyQnaStatus.ACTIVE)) {
+			status.or(qDailyQna.dailyQnaStatus.eq(DailyQnaStatus.ACTIVE));
+		}
+		if (statusList.contains(DailyQnaStatus.HIDDEN)) {
+			status.or(qDailyQna.dailyQnaStatus.eq(DailyQnaStatus.HIDDEN));
+		}
+		if (statusList.contains(DailyQnaStatus.DELETED)) {
+			status.or(qDailyQna.dailyQnaStatus.eq(DailyQnaStatus.DELETED));
+		}
+
+		return Optional.ofNullable(
+			jpaQueryFactory
+				.selectFrom(qDailyQna)
+				.where(
+					qDailyQna.id.eq(dailyQnaId),
+					status
+				)
+				.fetchFirst()
+		);
+	}
+
+	@Override
+	public List<DailyQna> findDailyQna(Long userId, Long questionId) {
+		return jpaQueryFactory
+			.selectFrom(qDailyQna)
+			.join(qUser).on(qUser.id.eq(qDailyQna.user.id)).fetchJoin()
+			.join(qQuestion).on(qQuestion.id.eq(qDailyQna.question.id)).fetchJoin()
+			.where(
+				qDailyQna.user.id.eq(userId),
+				qDailyQna.question.id.eq(questionId),
+				qDailyQna.dailyQnaStatus.eq(DailyQnaStatus.ACTIVE)
+			)
+			.orderBy(qDailyQna.createdAt.desc())
+			.fetch();
+	}
+
+	@Override
+	public Page<DailyQna> findDailyQnaPageByStatus(List<DailyQnaStatus> statusList, Long userId, Pageable pageable) {
+		BooleanBuilder status = new BooleanBuilder();
+
+		if (statusList.contains(DailyQnaStatus.ACTIVE)) {
+			status.or(qDailyQna.dailyQnaStatus.eq(DailyQnaStatus.ACTIVE));
+		}
+		if (statusList.contains(DailyQnaStatus.HIDDEN)) {
+			status.or(qDailyQna.dailyQnaStatus.eq(DailyQnaStatus.HIDDEN));
+		}
+		if (statusList.contains(DailyQnaStatus.DELETED)) {
+			status.or(qDailyQna.dailyQnaStatus.eq(DailyQnaStatus.DELETED));
+		}
+
+		JPAQuery<DailyQna> query = jpaQueryFactory
+			.selectFrom(qDailyQna)
+			.join(qDailyQna.user, qUser).fetchJoin()
+			.where(
+				qDailyQna.user.id.eq(userId),
+				status
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize());
+
+		for (Sort.Order o : pageable.getSort()) {
+			query.orderBy(new OrderSpecifier(o.isAscending() ? Order.ASC : Order.DESC,
+				pathBuilder.get(o.getProperty()))
+			);
+		}
+
+		Long total = jpaQueryFactory
+			.select(qDailyQna.count())
+			.from(qDailyQna)
+			.where(
+				qDailyQna.user.id.eq(userId),
+				status
+			)
+			.fetchOne();
+		List<DailyQna> dailyQnaList = query.fetch();
+		return new PageImpl<>(dailyQnaList, pageable, total);
+	}
+
+	@Override
+	public Optional<DailyQnaStatus> findDailyQnaStatusById(Long dailyQnaId) {
+		return Optional.ofNullable(
+			jpaQueryFactory
+				.select(qDailyQna.dailyQnaStatus)
+				.from(qDailyQna)
+				.where(
+					qDailyQna.id.eq(dailyQnaId)
+				)
+				.fetchFirst()
+		);
 	}
 }

--- a/src/main/java/com/study/petory/domain/dailyQna/repository/QuestionCustomRepository.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/repository/QuestionCustomRepository.java
@@ -1,25 +1,23 @@
 package com.study.petory.domain.dailyQna.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.study.petory.domain.dailyQna.entity.Question;
+import com.study.petory.domain.dailyQna.entity.QuestionStatus;
 
 public interface QuestionCustomRepository {
 
 	boolean existsByDate(String date);
 
-	Page<Question> findQuestionByPage(Pageable pageable);
+	Optional<Question> findQuestionByStatusAndId(List<QuestionStatus> statusList, Long questionId);
+
+	Page<Question> findQuestionPageByStatus(List<QuestionStatus> statusList, Pageable pageable);
 
 	Optional<Question> findTodayQuestion(String date);
 
-	Optional<Question> findQuestionByActive(Long questionId);
-
-	Optional<Question> findQuestionByActiveOrInactive(Long questionId);
-
-	Page<Question> findQuestionByInactive(Pageable pageable);
-
-	Page<Question> findQuestionByDeleted(Pageable pageable);
+	Optional<QuestionStatus> findQuestionStatusById(Long questionId);
 }

--- a/src/main/java/com/study/petory/domain/dailyQna/repository/QuestionCustomRepositoryImpl.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/repository/QuestionCustomRepositoryImpl.java
@@ -76,7 +76,6 @@ public class QuestionCustomRepositoryImpl implements QuestionCustomRepository {
 			)
 			.fetchOne();
 
-		// 오류 발생 위치
 		List<Question> questionList = query.fetch();
 
 		return new PageImpl<>(questionList, pageable, total);

--- a/src/main/java/com/study/petory/domain/dailyQna/repository/QuestionCustomRepositoryImpl.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/repository/QuestionCustomRepositoryImpl.java
@@ -6,8 +6,14 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.study.petory.domain.dailyQna.entity.QQuestion;
 import com.study.petory.domain.dailyQna.entity.Question;
@@ -21,7 +27,9 @@ public class QuestionCustomRepositoryImpl implements QuestionCustomRepository {
 
 	private final JPAQueryFactory jpaQueryFactory;
 
-	private final QQuestion qQuestion = QQuestion.question1;
+	private final QQuestion qQuestion = QQuestion.question;
+
+	private final PathBuilder pathBuilder = new PathBuilder<>(Question.class, "question");
 
 	@Override
 	public boolean existsByDate(String date) {
@@ -35,104 +43,91 @@ public class QuestionCustomRepositoryImpl implements QuestionCustomRepository {
 	}
 
 	@Override
-	public Page<Question> findQuestionByPage(Pageable pageable) {
-		List<Question> list = jpaQueryFactory
+	public Page<Question> findQuestionPageByStatus(List<QuestionStatus> statusList, Pageable pageable) {
+		BooleanBuilder status = new BooleanBuilder();
+		if (statusList.contains(QuestionStatus.ACTIVE)) {
+			status.or(qQuestion.questionStatus.eq(QuestionStatus.ACTIVE));
+		}
+		if (statusList.contains(QuestionStatus.INACTIVE)) {
+			status.or(qQuestion.questionStatus.eq(QuestionStatus.INACTIVE));
+		}
+		if (statusList.contains(QuestionStatus.DELETED)) {
+			status.or(qQuestion.questionStatus.eq(QuestionStatus.DELETED));
+		}
+
+		JPAQuery<Question> query = jpaQueryFactory
 			.selectFrom(qQuestion)
 			.where(
-				qQuestion.questionStatus.in(QuestionStatus.ACTIVE, QuestionStatus.INACTIVE)
+				status
 			)
 			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
+			.limit(pageable.getPageSize());
+
+		for (Sort.Order o : pageable.getSort()) {
+			query.orderBy(new OrderSpecifier(o.isAscending() ? Order.ASC : Order.DESC,
+				pathBuilder.get(o.getProperty())));
+		}
 
 		Long total = jpaQueryFactory
 			.select(qQuestion.count())
 			.from(qQuestion)
+			.where(
+				status
+			)
 			.fetchOne();
-		if (total == null) {
-			total = 0L;
-		}
-		return new PageImpl<>(list, pageable, total);
+
+		// 오류 발생 위치
+		List<Question> questionList = query.fetch();
+
+		return new PageImpl<>(questionList, pageable, total);
 	}
 
 	@Override
 	public Optional<Question> findTodayQuestion(String date) {
-		return jpaQueryFactory
-			.selectFrom(qQuestion)
-			.where(
-				qQuestion.date.eq(date),
-				qQuestion.questionStatus.eq(QuestionStatus.ACTIVE)
-			)
-			.fetch()
-			.stream().findAny();
+		return Optional.ofNullable(
+			jpaQueryFactory
+				.selectFrom(qQuestion)
+				.where(
+					qQuestion.date.eq(date),
+					qQuestion.questionStatus.eq(QuestionStatus.ACTIVE)
+				)
+				.fetchFirst()
+		);
 	}
 
 	@Override
-	public Optional<Question> findQuestionByActive(Long questionId) {
-		return jpaQueryFactory
-			.selectFrom(qQuestion)
-			.where(
-				qQuestion.id.eq(questionId),
-				qQuestion.questionStatus.eq(QuestionStatus.ACTIVE)
-			)
-			.stream().findAny();
-	}
-
-	public Page<Question> findQuestionByInactive(Pageable pageable) {
-		List<Question> questionPage = jpaQueryFactory
-			.selectFrom(qQuestion)
-			.where(
-				qQuestion.questionStatus.eq(QuestionStatus.INACTIVE)
-			)
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
-
-		Long total = jpaQueryFactory
-			.select(qQuestion.count())
-			.from(qQuestion)
-			.where(
-				qQuestion.questionStatus.eq(QuestionStatus.INACTIVE)
-			)
-			.fetchOne();
-		if (total == null) {
-			total = 0L;
+	public Optional<Question> findQuestionByStatusAndId(List<QuestionStatus> statusList, Long questionId) {
+		BooleanBuilder status = new BooleanBuilder();
+		if (statusList.contains(QuestionStatus.ACTIVE)) {
+			status.or(qQuestion.questionStatus.eq(QuestionStatus.ACTIVE));
 		}
-		return new PageImpl<>(questionPage, pageable, total);
+		if (statusList.contains(QuestionStatus.INACTIVE)) {
+			status.or(qQuestion.questionStatus.eq(QuestionStatus.INACTIVE));
+		}
+		if (statusList.contains(QuestionStatus.DELETED)) {
+			status.or(qQuestion.questionStatus.eq(QuestionStatus.DELETED));
+		}
+		return Optional.ofNullable(
+			jpaQueryFactory
+				.selectFrom(qQuestion)
+				.where(
+					qQuestion.id.eq(questionId),
+					status
+				)
+				.fetchFirst()
+		);
 	}
 
 	@Override
-	public Page<Question> findQuestionByDeleted(Pageable pageable) {
-		List<Question> questionPage = jpaQueryFactory
-			.selectFrom(qQuestion)
-			.where(
-				qQuestion.questionStatus.eq(QuestionStatus.DELETED)
-			)
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
-
-		Long total = jpaQueryFactory
-			.select(qQuestion.count())
-			.from(qQuestion)
-			.where(
-				qQuestion.questionStatus.eq(QuestionStatus.DELETED)
-			)
-			.fetchOne();
-		if (total == null) {
-			total = 0L;
-		}
-		return new PageImpl<>(questionPage, pageable, total);
-	}
-
-	public Optional<Question> findQuestionByActiveOrInactive(Long questionId) {
-		return jpaQueryFactory
-			.selectFrom(qQuestion)
-			.where(
-				qQuestion.id.eq(questionId),
-				qQuestion.questionStatus.in(QuestionStatus.ACTIVE, QuestionStatus.INACTIVE)
-			)
-			.fetch()
-			.stream().findAny();
+	public Optional<QuestionStatus> findQuestionStatusById(Long questionId) {
+		return Optional.ofNullable(
+			jpaQueryFactory
+				.select(qQuestion.questionStatus)
+				.from(qQuestion)
+				.where(
+					qQuestion.id.eq(questionId)
+				)
+				.fetchFirst()
+		);
 	}
 }

--- a/src/main/java/com/study/petory/domain/dailyQna/service/DailyQnaService.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/service/DailyQnaService.java
@@ -8,15 +8,16 @@ import org.springframework.data.domain.Pageable;
 import com.study.petory.domain.dailyQna.dto.request.DailyQnaCreateRequestDto;
 import com.study.petory.domain.dailyQna.dto.request.DailyQnaUpdateRequestDto;
 import com.study.petory.domain.dailyQna.dto.response.DailyQnaGetDeletedResponse;
-import com.study.petory.domain.dailyQna.dto.response.DailyQnaGetHiddenResponse;
+import com.study.petory.domain.dailyQna.dto.response.DailyQnaGetHiddenResponseDto;
 import com.study.petory.domain.dailyQna.dto.response.DailyQnaGetResponseDto;
 import com.study.petory.domain.dailyQna.entity.DailyQna;
+import com.study.petory.domain.dailyQna.entity.DailyQnaStatus;
 
 public interface DailyQnaService {
 
-	DailyQna findDailyQnaByDailyQnaId(Long dailyQnaId);
+	DailyQna findDailyQnaByStatusAndId(List<DailyQnaStatus> statusList, Long dailyQnaId);
 
-	DailyQna findDailyQnaByActive(Long dailyQnaId);
+	DailyQnaStatus findDailyQnaStatusById(Long dailyQnaId);
 
 	void validateAuthor(Long userId, DailyQna dailyQna);
 
@@ -28,7 +29,7 @@ public interface DailyQnaService {
 
 	void hideDailyQna(Long userId, Long dailyQnaId);
 
-	Page<DailyQnaGetHiddenResponse> findHiddenDailyQna(Long userId, Pageable pageable);
+	Page<DailyQnaGetHiddenResponseDto> findHiddenDailyQna(Long userId, Pageable pageable);
 
 	void updateDailyQnaStatusActive(Long userId, Long dailyQnaId);
 

--- a/src/main/java/com/study/petory/domain/dailyQna/service/QuestionService.java
+++ b/src/main/java/com/study/petory/domain/dailyQna/service/QuestionService.java
@@ -1,28 +1,21 @@
 package com.study.petory.domain.dailyQna.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.study.petory.domain.dailyQna.dto.request.QuestionCreateRequestDto;
 import com.study.petory.domain.dailyQna.dto.request.QuestionUpdateRequestDto;
 import com.study.petory.domain.dailyQna.dto.response.QuestionGetAllResponseDto;
-import com.study.petory.domain.dailyQna.dto.response.QuestionGetDeletedResponse;
+import com.study.petory.domain.dailyQna.dto.response.QuestionGetDeletedResponseDto;
 import com.study.petory.domain.dailyQna.dto.response.QuestionGetInactiveResponseDto;
 import com.study.petory.domain.dailyQna.dto.response.QuestionGetOneResponseDto;
 import com.study.petory.domain.dailyQna.dto.response.QuestionGetTodayResponseDto;
 import com.study.petory.domain.dailyQna.entity.Question;
+import com.study.petory.domain.dailyQna.entity.QuestionStatus;
 
 public interface QuestionService {
-
-	void setQuestion();
-
-	Question findQuestionByQuestionId(Long questionId);
-
-	Question findQuestionByActive(Long questionId);
-
-	Question findQuestionByActiveOrInactive(Long questionId);
-
-	void existsByDate(String date);
 
 	void saveQuestion(QuestionCreateRequestDto request);
 
@@ -42,7 +35,13 @@ public interface QuestionService {
 
 	void deactivateQuestion(Long questionId);
 
-	Page<QuestionGetDeletedResponse> findQuestionByDeleted(Pageable pageable);
+	Page<QuestionGetDeletedResponseDto> findQuestionByDeleted(Pageable pageable);
 
 	void restoreQuestion(Long questionId);
+
+	void setQuestion();
+
+	void existsByDate(String date);
+
+	Question findQuestionByIdAndStatus(List<QuestionStatus> statusList, Long questionId);
 }

--- a/src/test/java/com/study/petory/domain/album/AlbumServiceTest.java
+++ b/src/test/java/com/study/petory/domain/album/AlbumServiceTest.java
@@ -23,6 +23,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.study.petory.common.security.CustomPrincipal;
 import com.study.petory.common.util.AbstractImageService;
 import com.study.petory.domain.album.dto.request.AlbumCreateRequestDto;
 import com.study.petory.domain.album.dto.request.AlbumUpdateRequestDto;
@@ -234,18 +235,19 @@ public class AlbumServiceTest {
 	@DisplayName("단일 앨범을 조회한다.")
 	public void findOneAlbum() {
 		// given
-		Long userId = null;
+		Long userId = 1L;
 		Long albumId = 1L;
 		int imageSize = 3;
 
 		setImageSize(imageSize);
 
-		AlbumGetOneResponseDto dto = AlbumGetOneResponseDto.from(testAlbum);
+		CustomPrincipal customUser = new CustomPrincipal(userId, "email.com", "별명", List.of());
 
 		given(albumRepository.findOneAlbumByUser(true, albumId)).willReturn(Optional.of(testAlbum));
+		given(albumRepository.isUserAlbum(userId, albumId)).willReturn(false);
 
 		// when
-		AlbumGetOneResponseDto response = albumService.findOneAlbum(userId, albumId);
+		AlbumGetOneResponseDto response = albumService.findOneAlbum(customUser, albumId);
 
 		// then
 		assertThat(response.getAlbumId()).isEqualTo(1L);


### PR DESCRIPTION
## #️⃣이슈 번호

close #98


## 📝작업 상세 내용

Question domain
- [ ] Question Entity 필드명 수정 question -> content
- [ ] question domain QueryDSL 동적 정렬
- [ ] question domain QueryDSL 파라미터에 상태 타입의 List 추가로 범용성 증가
- [ ] ErrorCode 추가
- [ ] 테스트 코드 수정
- [ ] 일부 dto 명 dto 누락으로 수정

Album domain
- [ ] 비회원 요청 중 Album 단일 조회 시 본인의 앨범이라면 비공개 앨범도 조회


## 💬리뷰 요구사항 (선택)
필드명이 앤티티 명과 동일해서 발생한 q클래스 별칭명 오류

정상적인 명칭: question
현재 명칭: question1

![image](https://github.com/user-attachments/assets/57272283-4e79-46fd-ac64-26b293949fc6)



